### PR TITLE
Replacing javafx.util.Pair with org.apache.commons.lang3.tuple.MutablePair

### DIFF
--- a/drkafka/doctorkafka.iml
+++ b/drkafka/doctorkafka.iml
@@ -7,6 +7,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -15,7 +16,6 @@
     <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.4" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:21.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-configuration2:2.1.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.3.2" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-math3:3.6.1" level="project" />
     <orderEntry type="library" name="Maven: commons-beanutils:commons-beanutils:1.9.3" level="project" />
@@ -95,5 +95,6 @@
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.8.4" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-scala_2.12:2.8.4" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-paranamer:2.8.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.6" level="project" />
   </component>
 </module>

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
@@ -2,8 +2,8 @@ package com.pinterest.doctorkafka.notification;
 
 import com.pinterest.doctorkafka.KafkaBroker;
 
-import javafx.util.Pair;
 import kafka.cluster.Broker;
+import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
@@ -93,7 +93,7 @@ public class Email {
   public static void alertOnFailureInHandlingUrps(String[] emails,
                                                   String clusterName,
                                                   List<PartitionInfo> urps,
-                                                  List<Pair<KafkaBroker, TopicPartition>>
+                                                  List<MutablePair<KafkaBroker, TopicPartition>>
                                                       reassignmentFailures) {
     if (urpFailureEmails.containsKey(clusterName) &&
         System.currentTimeMillis() - urpFailureEmails.get(clusterName) < COOLOFF_INTERVAL) {

--- a/kafkastats/kafkastats.iml
+++ b/kafkastats/kafkastats.iml
@@ -5,6 +5,7 @@
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/avro" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -52,5 +53,6 @@
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.8.4" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-scala_2.12:2.8.4" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-paranamer:2.8.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.6" level="project" />
   </component>
 </module>

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
@@ -4,7 +4,7 @@ package com.pinterest.doctorkafka.util;
 import com.pinterest.doctorkafka.BrokerStats;
 
 import com.google.common.net.HostAndPort;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.MutablePair;
 import kafka.cluster.Broker;
 import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
@@ -196,7 +196,7 @@ public class OperatorUtil {
     }
   }
 
-  public static Pair<Long, Long> getProcNetDevStats() throws Exception {
+  public static MutablePair<Long, Long> getProcNetDevStats() throws Exception {
     ProcessBuilder ps = new ProcessBuilder("cat", "/proc/net/dev");
     Process pr = ps.start();
     pr.waitFor();
@@ -219,20 +219,20 @@ public class OperatorUtil {
     }
     in.close();
 
-    Pair<Long, Long> result = new Pair<>(receivedBytes, outBytes);
+    MutablePair<Long, Long> result = new MutablePair<>(receivedBytes, outBytes);
     return result;
   }
 
-  public static Pair<Double, Double> getSysNetworkTraffic(long samplingWindowInMs)
+  public static MutablePair<Double, Double> getSysNetworkTraffic(long samplingWindowInMs)
       throws Exception {
-    Pair<Long, Long> startNumbers = getProcNetDevStats();
+    MutablePair<Long, Long> startNumbers = getProcNetDevStats();
     Thread.sleep(samplingWindowInMs);
-    Pair<Long, Long> endNumbers = getProcNetDevStats();
+    MutablePair<Long, Long> endNumbers = getProcNetDevStats();
 
     double inRate = (endNumbers.getKey() - startNumbers.getKey()) * 1000.0 / samplingWindowInMs;
     double outRate =
         (endNumbers.getValue() - startNumbers.getValue()) * 1000.0 / samplingWindowInMs;
-    Pair<Double, Double> result = new Pair<>(inRate, outRate);
+    MutablePair<Double, Double> result = new MutablePair<>(inRate, outRate);
     return result;
   }
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -61,5 +61,11 @@
             <artifactId>ostrich_2.12</artifactId>
             <version>9.27.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.6</version>
+        </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
This PR removes the javafx dependency, enabling OpenJDK builds without Openjfx.
Fixing: https://github.com/pinterest/doctorkafka/issues/3