### PR TITLE
Doctor Kafka enhancement: adding the capabilty to fetch offset/data

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaBroker.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaBroker.java
@@ -124,6 +124,17 @@ public class KafkaBroker implements Comparable<KafkaBroker> {
     return false;
   }
 
+  public List<TopicPartition> getLeaderTopicPartitions() {
+    BrokerStats brokerStats = getLatestStats();
+    if (brokerStats == null) {
+      LOG.error("Failed to get brokerstats for {}:{}", clusterConfig.getClusterName(), brokerId);
+      return null;
+    }
+    List<TopicPartition> topicPartitions = new ArrayList<>();
+    brokerStats.getLeaderReplicas().stream().forEach(atp ->
+        topicPartitions.add(new TopicPartition(atp.getTopic(), atp.getPartition())));
+    return topicPartitions;
+  }
 
   public List<TopicPartition> getFollowerTopicPartitions() {
     BrokerStats brokerStats = getLatestStats();

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
@@ -693,7 +693,7 @@ public class KafkaClusterManager implements Runnable {
   private boolean isDeadBroker(String host, int brokerId, TopicPartition tp) {
     if (OperatorUtil.pingKafkaBroker(host, 9092, 5000)) {
       LOG.debug("Broker {} is alive as {}:9092 is reachable", brokerId, host);
-      if (OperatorUtil.fetchData(host, 9092, tp.topic(), tp.partition())) {
+      if (OperatorUtil.canFetchData(host, 9092, tp.topic(), tp.partition())) {
         LOG.debug("We are able to fetch data from broker {}", brokerId);
         return false;
       } else {

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
@@ -96,7 +96,7 @@ public class Email {
                                                   List<PartitionInfo> urps,
                                                   List<MutablePair<KafkaBroker, TopicPartition>>
                                                       reassignmentFailures,
-                                                  Set<String> downBrokers) {
+                                                  Set<Integer> downBrokers) {
     if (urpFailureEmails.containsKey(clusterName) &&
         System.currentTimeMillis() - urpFailureEmails.get(clusterName) < COOLOFF_INTERVAL) {
       // return to avoid spamming users if an email has been sent within the coll-time time span

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class Email {
@@ -94,7 +95,8 @@ public class Email {
                                                   String clusterName,
                                                   List<PartitionInfo> urps,
                                                   List<MutablePair<KafkaBroker, TopicPartition>>
-                                                      reassignmentFailures) {
+                                                      reassignmentFailures,
+                                                  Set<String> downBrokers) {
     if (urpFailureEmails.containsKey(clusterName) &&
         System.currentTimeMillis() - urpFailureEmails.get(clusterName) < COOLOFF_INTERVAL) {
       // return to avoid spamming users if an email has been sent within the coll-time time span
@@ -114,6 +116,10 @@ public class Email {
         TopicPartition topicPartition = pair.getValue();
         sb.append("Broker : " + broker.name() + ", " + topicPartition);
       });
+    }
+    if (downBrokers != null && !downBrokers.isEmpty()) {
+      sb.append("Down brokers: \n");
+      sb.append(downBrokers);
     }
     String content = sb.toString();
     sendTo(emails, title, content);

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/util/UnderReplicatedReason.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/util/UnderReplicatedReason.java
@@ -2,6 +2,8 @@ package com.pinterest.doctorkafka.util;
 
 public enum UnderReplicatedReason {
   BROKER_FAILURE,
+  LEADER_FAILURE,
+  NO_LEADER_FAILURE,
   DEGRADED_HARDWARE,
   FOLLOWER_NETWORK_SATURATION,
   LEADER_NETWORK_SATURATION,

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/util/UnderReplicatedReason.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/util/UnderReplicatedReason.java
@@ -1,7 +1,7 @@
 package com.pinterest.doctorkafka.util;
 
 public enum UnderReplicatedReason {
-  BROKER_FAILURE,
+  FOLLOWER_FAILURE,
   LEADER_FAILURE,
   NO_LEADER_FAILURE,
   DEGRADED_HARDWARE,

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
@@ -5,7 +5,16 @@ import com.pinterest.doctorkafka.BrokerStats;
 
 import com.google.common.net.HostAndPort;
 import org.apache.commons.lang3.tuple.MutablePair;
+
+import kafka.api.FetchRequest;
+import kafka.api.FetchRequestBuilder;
+import kafka.api.FetchResponse;
+import kafka.api.Request;
 import kafka.cluster.Broker;
+import kafka.common.TopicAndPartition;
+import kafka.consumer.ConsumerConfig;
+import kafka.consumer.SimpleConsumer;
+import kafka.message.MessageSet;
 import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.ZkConnection;
@@ -48,6 +57,10 @@ public class OperatorUtil {
   public static final int WINDOW_SIZE = 6000;
   public static final String HostName = getHostname();
   private static final DecoderFactory avroDecoderFactory = DecoderFactory.get();
+  private static final String FETCH_CLIENT_NAME = "DoctorKafka";
+  private static final int FETCH_BUFFER_SIZE = 1024 * 1024;
+  private static final int FETCH_RETRIES = 3;
+  private static final int FETCH_MAX_WAIT_MS = 1; // this is the same wait as simmpleConsumerShell
 
   public static String getHostname() {
     String hostName;
@@ -87,10 +100,88 @@ public class OperatorUtil {
       socket.connect(new InetSocketAddress(host, port), timeout);
       return true;
     } catch (UnknownHostException e) {
+      LOG.warn("Ping failure, host: " + host, e);
       return false;
     } catch (IOException e) {
+      LOG.warn("Ping failure IO, host: " + host, e);
       return false; // Either timeout or unreachable or failed DNS lookup.
     }
+  }
+
+  public static boolean fetchData(String host, int port, String topic, int partition) {
+    LOG.info("Fetching data from host {}, topic {}, partition {}", host, topic, partition);
+    SimpleConsumer consumer = new SimpleConsumer(host, port,
+        ConsumerConfig.SocketTimeout(), ConsumerConfig.SocketBufferSize(), FETCH_CLIENT_NAME);
+    try {
+      long earlyOffset = getOffset(consumer, topic, partition,
+          kafka.api.OffsetRequest.EarliestTime());
+      long latestOffset = getOffset(consumer, topic, partition,
+          kafka.api.OffsetRequest.LatestTime());
+      long readOffset = (earlyOffset + latestOffset) / 2;
+      LOG.info("earlyOffset: " + earlyOffset + " latestOffset: " + latestOffset +
+          " readOffset: " + readOffset);
+      for (int i = 0; i < FETCH_RETRIES; i++) {
+        FetchRequest req = new FetchRequestBuilder()
+            .clientId(FETCH_CLIENT_NAME)
+            .replicaId(Request.DebuggingConsumerId()) // this consumerId enable reads from follower
+            .maxWait(FETCH_MAX_WAIT_MS)
+            .minBytes(ConsumerConfig.MinFetchBytes())
+            .addFetch(topic, partition, readOffset, FETCH_BUFFER_SIZE)
+            .build();
+        FetchResponse response = consumer.fetch(req);
+
+        if (response.hasError()) {
+          String errMsg = "Error fetching Data. ErrorCode: " + response.error(topic, partition);
+          LOG.warn(errMsg);
+        } else {
+          MessageSet msgSet = response.messageSet(topic, partition);
+          if (msgSet.sizeInBytes() <= 0) {
+            LOG.warn("host: " + host + " topic: " + topic + " par: " + partition +
+                " Not enough bytes: {}", msgSet.sizeInBytes());
+          } else {
+            LOG.info("Passed. Fetching data from host {}, topic {}, partition {}",
+                host, topic, partition);
+            return true;
+          }
+        }
+        try {
+          Thread.sleep((long) (Math.random() * 3000));
+        } catch (InterruptedException ex) {
+          LOG.warn("Unexpected interruption", ex);
+        }
+      }
+    } catch (IOException ex) {
+      LOG.warn("For host: " + host + " Unexpected exception", ex);
+    } finally {
+      consumer.close();
+    }
+    LOG.warn("Failed Fetching data from host {}, topic {}, parttion {}", host, topic, partition);
+    return false;
+  }
+
+  public static long getOffset(SimpleConsumer consumer, String topic, int partition,
+                               long whichTime) throws IOException {
+    String errMsg = null;
+    Exception lastEx = null;
+    for (int i = 0; i < FETCH_RETRIES; i++) {
+      TopicAndPartition topicAndPartition = new TopicAndPartition(topic, partition);
+      try {
+        long offset = consumer.earliestOrLatestOffset(topicAndPartition, whichTime,
+            Request.DebuggingConsumerId());
+        return offset;
+      } catch (RuntimeException e) {
+        lastEx = e;
+        errMsg = "Failed to getting offset for topic: " + topic + " partition: " + partition
+            + " host: " + consumer.host();
+        LOG.warn(errMsg, e);
+        try {
+          Thread.sleep((long) (Math.random() * 3000));
+        } catch (InterruptedException ex) {
+          LOG.warn("Unexpected interruption", ex);
+        }
+      }
+    }
+    throw new IOException(errMsg, lastEx);
   }
 
   private static Map<String, KafkaConsumer> kafkaConsumers = new HashMap();

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
@@ -109,7 +109,7 @@ public class OperatorUtil {
     }
   }
 
-  public static boolean fetchData(String host, int port, String topic, int partition) {
+  public static boolean canFetchData(String host, int port, String topic, int partition) {
     LOG.info("Fetching data from host {}, topic {}, partition {}", host, topic, partition);
     SimpleConsumer consumer = new SimpleConsumer(host, port,
         FETCH_SOCKET_TIMEOUT, ConsumerConfig.SocketBufferSize(), FETCH_CLIENT_NAME);


### PR DESCRIPTION
Currently Dr. Kafka only checks port 9092 to verify whether a broker is live or dead.  But in opeartion, we saw quite a few times that a broker is hanging but can still show port 9092 as active.

Added more checks (fetch an offset and then fetch data from the offset for that offset) to verfy whether the broker is really dead or alive.

On the next checkin, I will add some automatic active code for dead broker