### PR TITLE
When closing consumer also delete from hashmap

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/replicastats/ReplicaStatsManager.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/replicastats/ReplicaStatsManager.java
@@ -270,7 +270,7 @@ public class ReplicaStatsManager {
     kafkaConsumer.unsubscribe();
     kafkaConsumer.assign(offsets.keySet());
     Map<TopicPartition, Long> latestOffsets = kafkaConsumer.endOffsets(offsets.keySet());
-    kafkaConsumer.close();
+    KafkaUtils.closeConsumer(zkUrl);
 
     List<PastReplicaStatsProcessor> processors = new ArrayList<>();
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/tools/BrokerStatsFilter.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/tools/BrokerStatsFilter.java
@@ -139,7 +139,7 @@ public class BrokerStatsFilter {
     kafkaConsumer.unsubscribe();
     kafkaConsumer.assign(offsets.keySet());
     Map<TopicPartition, Long> latestOffsets = kafkaConsumer.endOffsets(offsets.keySet());
-    kafkaConsumer.close();
+    KafkaUtils.closeConsumer(brokerStatsZk);
 
     Map<Long, BrokerStats> brokerStatsMap = new TreeMap<>();
     for (TopicPartition topicPartition : offsets.keySet()) {

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/util/KafkaUtils.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/util/KafkaUtils.java
@@ -125,6 +125,14 @@ public class KafkaUtils {
   }
 
 
+  public static void closeConsumer(String zkUrl) {
+    if (kafkaConsumers.containsKey(zkUrl)) {
+      kafkaConsumers.get(zkUrl).close();
+      kafkaConsumers.remove(zkUrl);
+    }
+  }
+
+
   public static class TopicPartitionComparator implements Comparator<TopicPartition> {
 
     @Override


### PR DESCRIPTION
Because of the way kafkaconsumer objects are stored and accessed through
KafkaUtils we need to delete those objects upon connection close,
otherwise if we get the object using zkconnectionurl -string we get an
consumer object that has already been closed.

Using an object that is already closed will cause
java.lang.IllegalStateException and that's of course not a perfect
situation. This change also allows using the same zk connectstring for
managed cluster and kafkastats, which especially makes development
easier because you don't have to setup two clusters.

A better fix would probably be to inherit KafkaConsumer and make the
close to make sure that the object gets alos deleted from everywhere
else, but this is sufficient enough at this point.