### PR TITLE
Detection for diskfailure with multiple log dirs

### DIFF
--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
@@ -455,18 +455,22 @@ public class BrokerStatsRetriever {
       String logDirsStr = properties.containsKey("log.dirs") ? properties.getProperty("log.dirs")
                                                              : properties.getProperty("log.dir");
       brokerStats.setLogFilesPath(logDirsStr);
+      long freeSpaceInBytes = 0;
+      long totalSpaceInBytes = 0;
 
-      File logDir = new File(logDirsStr);
-      if (!logDir.exists()) {
-        brokerStats.setHasFailure(true);
-        brokerStats.setFailureReason(BrokerError.DiskFailure);
-        return;
+      for (String logDir : logDirsStr.split(",")) {
+        File tmpDir = new File(logDir);
+        if (!tmpDir.exists()) {
+          brokerStats.setHasFailure(true);
+          brokerStats.setFailureReason(BrokerError.DiskFailure);
+          return;
+        } else {
+          freeSpaceInBytes += tmpDir.getFreeSpace();
+          totalSpaceInBytes += tmpDir.getTotalSpace();
+        }
       }
 
-      long freeSpaceInBytes = logDir.getFreeSpace();
       brokerStats.setFreeDiskSpaceInBytes(freeSpaceInBytes);
-
-      long totalSpaceInBytes = logDir.getTotalSpace();
       brokerStats.setTotalDiskSpaceInBytes(totalSpaceInBytes);
     } catch (Exception e) {
       LOG.error("Failed to get broker configuration", e);


### PR DESCRIPTION
The original implementation assumed that there's always just one log
dir. In larger kafka brokers there's usually multiple kafka log dirs, so
we need to take that into account when running the
setBrokerConfiguration -function.