### PR TITLE
Ui disambiguation

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/KafkaTopicStatsServlet.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/KafkaTopicStatsServlet.java
@@ -66,8 +66,8 @@ public class KafkaTopicStatsServlet extends HttpServlet {
     writer.print("<p> <h5>" + topic + "</h5></p>");
     writer.print("<table class=\"table\">");
     writer.print("<thead> <tr> <th> Partition</th> ");
-    writer.print("<th>In Max</th> ");
-    writer.print("<th>Out max</th>");
+    writer.print("<th>In Max (Mb/s)</th> ");
+    writer.print("<th>Out max (Mb/s)</th>");
     writer.print("</tr> </thead> <tbody>");
 
     int zeroTrafficPartitions = 0;
@@ -95,7 +95,7 @@ public class KafkaTopicStatsServlet extends HttpServlet {
       writer.print("</tr>");
     }
     writer.print("<tr> <td colspan=\"8\">" + zeroTrafficPartitions
-        + " empty partitions </td> </tr>");
+        + " zero traffic partitions </td> </tr>");
     writer.print("</tbody> </table>");
   }
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/tools/ClusterLoadBalancer.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/tools/ClusterLoadBalancer.java
@@ -101,7 +101,7 @@ public class ClusterLoadBalancer {
         clusterZk, kafkaCluster, clusterConf, ReplicaStatsManager.config, null, null);
 
     List<KafkaBroker> highTrafficBrokers = clusterManager.getHighTrafficBroker();
-    if (onlyOne) {
+    if (onlyOne && highTrafficBrokers.size() > 0) {
       KafkaBroker broker = highTrafficBrokers.get(0);
       highTrafficBrokers.clear();
       highTrafficBrokers.add(broker);


### PR DESCRIPTION
Also pulls in a trivial guard for the balancer to not throw an exception when there are no busy nodes, because that's kind of/sort of like UI.