### PR TITLE
reduce connection counts from KafkaStats via sharing producer

### DIFF
--- a/drkafka/Dockerfile
+++ b/drkafka/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y mailutils
 RUN apt-get update && apt-get install -y sendmail
 
 # Add the build artifact under /opt, can be overridden by docker build
-ARG ARTIFACT_PATH=target/doctorkafka-0.2.2-bin.tar.gz
+ARG ARTIFACT_PATH=target/doctorkafka-0.2.3-bin.tar.gz
 ADD $ARTIFACT_PATH /opt/doctorkafka/
 # default cmd
 CMD /opt/doctorkafka/scripts/run_in_container.sh

--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>doctorkafka-parent</artifactId>
         <groupId>com.github.pinterest</groupId>
-        <version>0.2.2</version>
+        <version>0.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drkafka/scripts/action_retriever.sh
+++ b/drkafka/scripts/action_retriever.sh
@@ -2,8 +2,7 @@
 
 set -x
 
-java -cp drkafka/target/lib/*:drkafka/target/doctorkafka-0.2.2.jar \
+java -cp drkafka/target/lib/*:drkafka/target/doctorkafka-0.2.3.jar \
      -Dlog4j.configurationFile=file:./drkafka/config/log4j2.dev.xml   \
      com.pinterest.doctorkafka.tools.DoctorKafkaActionRetriever   \
      $1 $2 $3 $4 $5 $6
-

--- a/drkafka/scripts/run.sh
+++ b/drkafka/scripts/run.sh
@@ -3,9 +3,8 @@
 set -x
 
 
-java8 -cp lib/*:kafkaoperator-0.2.2.jar  -Dlog4j.configurationFile=file:./log4j2.xml  \
+java8 -cp lib/*:kafkaoperator-0.2.3.jar  -Dlog4j.configurationFile=file:./log4j2.xml  \
       com.pinterest.doctorkafka.DoctorKafkaMain   \
       -topic brokerstats -zookeeper datazk001:2181/data07  \
       -ostrichport 2052 -tsdhostport localhost:18261 -uptimeinseconds 86400  \
       -config doctorkafka.prod.properties
-

--- a/drkafka/scripts/run_dev.sh
+++ b/drkafka/scripts/run_dev.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-java -cp drkafka/target/lib/*:drkafka/target/doctorkafka-0.2.2.jar \
+java -cp drkafka/target/lib/*:drkafka/target/doctorkafka-0.2.3.jar \
      -Dlog4j.configurationFile=file:./drkafka/config/log4j2.dev.xml   \
      com.pinterest.doctorkafka.DoctorKafkaMain   \
      -config  drkafka/config/doctorkafka.dev.properties \

--- a/drkafka/src/main/resources/versioning.properties
+++ b/drkafka/src/main/resources/versioning.properties
@@ -1,2 +1,2 @@
-version=0.2.2
+version=0.2.3
 artifactId=doctorkafka

--- a/kafkastats/pom.xml
+++ b/kafkastats/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.pinterest</groupId>
         <artifactId>doctorkafka-parent</artifactId>
-        <version>0.2.2</version>
+        <version>0.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsReporter.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsReporter.java
@@ -25,17 +25,15 @@ public class BrokerStatsReporter implements Runnable {
   private String brokerHost;
   private String jmxPort;
   private String kafkaConfigPath;
-  private String statsTopic;
-  private String zkUrl;
+  private KafkaAvroPublisher avroPublisher;
   private long pollingIntervalInSeconds;
 
   public BrokerStatsReporter(String kafkaConfigPath, String host, String jmxPort,
-                             String statsTopic, String zkUrl, long pollingIntervalInSeconds) {
+                             KafkaAvroPublisher avroPublisher, long pollingIntervalInSeconds) {
     this.brokerHost = host;
     this.jmxPort = jmxPort;
     this.kafkaConfigPath = kafkaConfigPath;
-    this.statsTopic = statsTopic;
-    this.zkUrl = zkUrl;
+    this.avroPublisher = avroPublisher;
     this.pollingIntervalInSeconds = pollingIntervalInSeconds;
   }
 
@@ -55,7 +53,6 @@ public class BrokerStatsReporter implements Runnable {
     BrokerStatsRetriever brokerStatsRetriever = new BrokerStatsRetriever(kafkaConfigPath);
     try {
       BrokerStats stats = brokerStatsRetriever.retrieveBrokerStats(brokerHost, jmxPort);
-      KafkaAvroPublisher avroPublisher = new KafkaAvroPublisher(statsTopic, zkUrl);
       avroPublisher.publish(stats);
       LOG.info("publised to kafka : {}", stats);
     } catch (Exception e) {

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaAvroPublisher.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaAvroPublisher.java
@@ -63,4 +63,8 @@ public class KafkaAvroPublisher {
       throw new RuntimeException("Avro serialization failure", e);
     }
   }
+
+  public void close() {
+    kafkaProducer.close();
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <name>doctorkafka-parent</name>
     <groupId>com.github.pinterest</groupId>
     <artifactId>doctorkafka-parent</artifactId>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <packaging>pom</packaging>
     <url>https://github.com/pinterest/doctorkafka</url>
 


### PR DESCRIPTION
make avroProducer shared across threads to reduce connection counts to brokers
make kafkastats shutdown more graceful
make avroPublisher available to shutdown thread and expose underlying producer.close()

bumped version also
