### PR TITLE
Add system network stats (interface stats) to Dr.Kafka

### DIFF
--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsReporter.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsReporter.java
@@ -27,14 +27,16 @@ public class BrokerStatsReporter implements Runnable {
   private String kafkaConfigPath;
   private KafkaAvroPublisher avroPublisher;
   private long pollingIntervalInSeconds;
+  private String primaryNetworkInterfaceName;
 
   public BrokerStatsReporter(String kafkaConfigPath, String host, String jmxPort,
-                             KafkaAvroPublisher avroPublisher, long pollingIntervalInSeconds) {
+                             KafkaAvroPublisher avroPublisher, long pollingIntervalInSeconds, String primaryNetworkInterfaceName) {
     this.brokerHost = host;
     this.jmxPort = jmxPort;
     this.kafkaConfigPath = kafkaConfigPath;
     this.avroPublisher = avroPublisher;
     this.pollingIntervalInSeconds = pollingIntervalInSeconds;
+    this.primaryNetworkInterfaceName = primaryNetworkInterfaceName;
   }
 
 
@@ -50,7 +52,7 @@ public class BrokerStatsReporter implements Runnable {
 
   @Override
   public void run() {
-    BrokerStatsRetriever brokerStatsRetriever = new BrokerStatsRetriever(kafkaConfigPath);
+    BrokerStatsRetriever brokerStatsRetriever = new BrokerStatsRetriever(kafkaConfigPath, primaryNetworkInterfaceName);
     try {
       BrokerStats stats = brokerStatsRetriever.retrieveBrokerStats(brokerHost, jmxPort);
       avroPublisher.publish(stats);

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaAvroPublisher.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaAvroPublisher.java
@@ -14,7 +14,6 @@ import org.apache.commons.compress.utils.IOUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -80,7 +79,7 @@ public class KafkaAvroPublisher {
       int partition = brokerStats.getId() % numPartitions;
 
       Future<RecordMetadata> future = kafkaProducer.send(
-          new ProducerRecord(destTopic, partition, key.getBytes(), stream.toByteArray()));
+          new ProducerRecord<>(destTopic, partition, key.getBytes(), stream.toByteArray()));
       future.get();
 
       OpenTsdbMetricConverter.incr("kafka.stats.collector.success", 1, "host=" + HOSTNAME);

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaMetricRetrievingTask.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaMetricRetrievingTask.java
@@ -1,16 +1,10 @@
 package com.pinterest.doctorkafka.stats;
 
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.concurrent.Callable;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
 public class KafkaMetricRetrievingTask implements Callable<KafkaMetricValue> {
-
-  private static final Logger LOG = LogManager.getLogger(KafkaMetricRetrievingTask.class);
 
   private MBeanServerConnection mbs;
   private String metricName;


### PR DESCRIPTION
Add system network stats (interface stats) to Dr.Kafka:
- can be used for more accurate load calculation during rebalancing
- apply network load limits to Kafka brokers for partition assignment


Cleaning up unused imports / code
Fixing generics