### PR TITLE
Support for cluster maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,19 @@ usage does not exceed the threshold.
 
 ## DoctorKafka UI 
 
-DoctorKafka uses an embedding Jetty server to provide a web UI. The following is the screenshot from a demo:
+DoctorKafka uses [dropwizard-core module](https://www.dropwizard.io/1.3.5/docs/manual/core.html) and [serving assets](https://www.dropwizard.io/1.3.5/docs/manual/core.html#serving-assets) to provide a web UI. The following is the screenshot from a demo:
 
 ![doctorkafka UI](docs/doctorkafka_ui.png)
 <img src="docs/doctorkafka_ui.png" width="160">
 
+## DoctorKafka APIs
+
+The following APIs are available for DoctorKafka:
+
+	- List Cluster
+	- Maintenance Mode
+
+Detailed description of APIs can be found [docs/APIs.md](docs/APIs.md)
 
 ## Maintainers
   * [Yu Yang](https://github.com/yuyang08)

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -1,0 +1,23 @@
+**Cluster Info API**
+
+Basic APIs to get Cluster Info:
+
+```
+List Cluster:  curl -XGET http://localhost:8080/api/cluster
+```
+
+
+**Maintenance Mode API**
+
+Allows users to disable DoctorKafka for a cluster so that manual maintenance operations can be performed on it without any interference from Dr. Kafka.
+
+GET will get the current status of maintenance mode.
+PUT will place the cluster in maintenance mode.
+DELETE will remove the cluster from maintenance mode.
+
+
+```
+curl -XGET http://localhost:8080/api/cluster/<clustername>/admin/maintenance
+curl -XPUT http://localhost:8080/api/cluster/<clustername>/admin/maintenance
+curl -XDELETE http://localhost:8080/api/cluster/<clustername>/admin/maintenance
+```

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafka.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafka.java
@@ -11,7 +11,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class DoctorKafka {
@@ -24,7 +27,7 @@ public class DoctorKafka {
 
   private DoctorKafkaActionReporter actionReporter = null;
 
-  private List<KafkaClusterManager> clusterManagers = new ArrayList<>();
+  private Map<String, KafkaClusterManager> clusterManagers = new HashMap<>();
 
   private Set<String> clusterZkUrls = null;
 
@@ -65,7 +68,7 @@ public class DoctorKafka {
       }
       KafkaClusterManager clusterManager = new KafkaClusterManager(
           clusterZkUrl, kafkaCluster, clusterConf, drkafkaConf, actionReporter, zookeeperClient);
-      clusterManagers.add(clusterManager);
+      clusterManagers.put(clusterConf.getClusterName(), clusterManager);
       clusterManager.start();
       LOG.info("Starting cluster manager for " + clusterZkUrl);
     }
@@ -74,7 +77,7 @@ public class DoctorKafka {
   public void stop() {
     brokerStatsProcessor.stop();
     zookeeperClient.close();
-    for (KafkaClusterManager clusterManager : clusterManagers) {
+    for (KafkaClusterManager clusterManager : clusterManagers.values()) {
       clusterManager.stop();
     }
   }
@@ -83,16 +86,15 @@ public class DoctorKafka {
     return drkafkaConf;
   }
 
-  public List<KafkaClusterManager> getClusterManagers() {
-    return clusterManagers;
+  public Collection<KafkaClusterManager> getClusterManagers() {
+    return clusterManagers.values();
   }
 
   public KafkaClusterManager getClusterManager(String clusterName) {
-    for (KafkaClusterManager clusterManager : clusterManagers) {
-      if (clusterManager.getClusterName().equals(clusterName)) {
-        return clusterManager;
-      }
-    }
-    return null;
+    return clusterManagers.get(clusterName);
+  }
+
+  public List<String> getClusterNames() {
+    return new ArrayList<>(clusterManagers.keySet());
   }
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/BrokerApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/BrokerApi.java
@@ -3,14 +3,19 @@ package com.pinterest.doctorkafka.api;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import com.pinterest.doctorkafka.DoctorKafkaMain;
 import com.pinterest.doctorkafka.KafkaClusterManager;
 
 @Path("/cluster/{clusterName}/broker")
+@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({ MediaType.APPLICATION_JSON })
 public class BrokerApi {
 
     @GET

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/ClusterApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/ClusterApi.java
@@ -1,0 +1,29 @@
+package com.pinterest.doctorkafka.api;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.pinterest.doctorkafka.DoctorKafka;
+
+@Path("/cluster")
+@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({ MediaType.APPLICATION_JSON })
+public class ClusterApi {
+
+  private DoctorKafka drKafka;
+
+  public ClusterApi(DoctorKafka drKafka) {
+    this.drKafka = drKafka;
+  }
+
+  @GET
+  public List<String> getClusterNames() {
+    return drKafka.getClusterNames();
+  }
+
+}

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/MaintenanceApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/MaintenanceApi.java
@@ -1,0 +1,65 @@
+package com.pinterest.doctorkafka.api;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.pinterest.doctorkafka.DoctorKafka;
+import com.pinterest.doctorkafka.KafkaClusterManager;
+
+@Path("/cluster/{clusterName}/admin/maintenance")
+@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({ MediaType.APPLICATION_JSON })
+public class MaintenanceApi {
+
+  private static final Logger LOG = LogManager.getLogger(MaintenanceApi.class);
+  private DoctorKafka drKafka;
+
+  public MaintenanceApi(DoctorKafka drKafka) {
+    this.drKafka = drKafka;
+  }
+
+  @GET
+  public boolean checkMaintenance(@PathParam("clusterName") String clusterName) {
+    KafkaClusterManager clusterManager = checkAndGetClusterManager(clusterName);
+    return clusterManager.isMaintenanceModeEnabled();
+  }
+
+  @PUT
+  public void enableMaintenance(@Context HttpServletRequest ctx,
+      @PathParam("clusterName") String clusterName) {
+    KafkaClusterManager clusterManager = checkAndGetClusterManager(clusterName);
+    clusterManager.enableMaintenanceMode();
+    LOG.info("Enabled maintenance mode for cluster:" + clusterName + " by user:"
+        + ctx.getRemoteUser() + " from ip:" + ctx.getRemoteHost());
+  }
+
+  @DELETE
+  public void disableMaintenance(@Context HttpServletRequest ctx,
+      @PathParam("clusterName") String clusterName) {
+    KafkaClusterManager clusterManager = checkAndGetClusterManager(clusterName);
+    clusterManager.disableMaintenanceMode();
+    LOG.info("Dsiabled maintenance mode for cluster:" + clusterName + " by user:"
+        + ctx.getRemoteUser() + " from ip:" + ctx.getRemoteHost());
+  }
+
+  private KafkaClusterManager checkAndGetClusterManager(String clusterName) {
+    KafkaClusterManager clusterManager = drKafka.getClusterManager(clusterName);
+    if (clusterManager == null) {
+      throw new NotFoundException("Unknown clustername:" + clusterName);
+    }
+    return clusterManager;
+  }
+
+}

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,6 +79,13 @@ public class Email {
   public static void notifyOnBrokerReplacement(String[] emails, String clusterName, String broker) {
     String title = clusterName + " broker replacement : " + broker;
     String content = "Replacing broker " + broker + " in cluster " + clusterName;
+    sendTo(emails, title, content);
+  }
+  
+  public static void notifyOnMaintenanceMode(String[] emails, String clusterName, boolean maintenanceMode) {
+    String title = maintenanceMode ? clusterName + " is in Maintenance mode" : " is out of Maintenance mode";
+    String content = "Cluster:" + clusterName + " was placed " + (maintenanceMode ? "in maintenance mode"
+        : "out of maintenance mode") + " at " + new Date();
     sendTo(emails, title, content);
   }
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/DoctorKafkaInfoServlet.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/DoctorKafkaInfoServlet.java
@@ -11,7 +11,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.servlet.ServletException;
@@ -38,31 +38,23 @@ public class DoctorKafkaInfoServlet extends HttpServlet {
       writer.print("<p> Version: " + version + ", Uptime: " + jvmUpTimeInSeconds + " seconds </p>");
       writer.print("</div>");
 
-      List<KafkaClusterManager> clusterManagers = DoctorKafkaMain.doctorKafka.getClusterManagers();
+      Collection<KafkaClusterManager> clusterManagers = DoctorKafkaMain.doctorKafka.getClusterManagers();
       writer.print("<div> ");
       writer.print("<table class=\"table table-responsive\"> ");
       writer.print("<th> ClusterName </th> <th> Size </th> <th> Under-replicated Partitions</th>");
+      writer.print("<th> Maintenance Mode </th>");
       writer.print("<tbody>");
 
       Map<String, String>  clustersHtml = new TreeMap<>();
       for (KafkaClusterManager clusterManager : clusterManagers) {
         String clusterName = clusterManager.getClusterName();
         String htmlStr;
-        if (clusterManager.getCluster() != null) {
-          htmlStr = "<tr> <td> <a href=\"/servlet/clusterinfo?name=" + clusterName + "\">"
+        htmlStr = "<tr> <td> <a href=\"/servlet/clusterinfo?name=" + clusterName + "\">"
               + clusterName + "</a>"
-              + " </td> <td> " + clusterManager.getClusterSize()
+              + " </td> <td> " + ((clusterManager.getCluster()!=null)? clusterManager.getClusterSize() : "no brokerstats")
               + " </td> <td> <a href=\"/servlet/urp?cluster=" + clusterName + "\">"
-              + clusterManager.getUnderReplicatedPartitions().size() + "</a>"
-              + " </td> </tr>";
-        } else {
-          htmlStr = "<tr> <td> <a href=\"/servlet/clusterinfo?name=" + clusterName + "\">"
-              + clusterName + "</a>"
-              + " </td> <td>  no brokerstats </td> "
-              + " <td> <a href=\"/servlet/urp?cluster=" + clusterName + "\">"
-              + clusterManager.getUnderReplicatedPartitions().size() + "</a>"
-              + " </td> </tr>";
-        }
+              + clusterManager.getUnderReplicatedPartitions().size() + "</a> </td>"
+              + "<td>" + clusterManager.isMaintenanceModeEnabled() + " </td> </tr>";
 
         clustersHtml.put(clusterName, htmlStr);
       }


### PR DESCRIPTION
**Purpose:**
Support for cluster maintenance mode to temporarily pause Doctor Kafka operations on a cluster.

**Description:**
Maintenance mode will disable Doctor Kafka for a cluster so manual operations like broker replacement, restarts etc. can be performed without triggering automated rebalances or broker replacements.

**APIs:**
```
curl -XGET http://localhost:8080/api/cluster/<clustername>/admin/maintenance
curl -XPUT http://localhost:8080/api/cluster/<clustername>/admin/maintenance
curl -XDELETE http://localhost:8080/api/cluster/<clustername>/admin/maintenance
```

```
curl -XGET http://localhost:8080/api/cluster
```