### PR TITLE
New PR for adding JSON output to the standard servlets

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaBroker.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaBroker.java
@@ -6,6 +6,10 @@ import com.pinterest.doctorkafka.replicastats.ReplicaStatsManager;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -17,6 +21,7 @@ import java.util.stream.Collectors;
 public class KafkaBroker implements Comparable<KafkaBroker> {
 
   private static final Logger LOG = LogManager.getLogger(KafkaBroker.class);
+  private static final Gson gson = new Gson();
   private DoctorKafkaClusterConfig clusterConfig;
   private String zkUrl;
   private int brokerId;
@@ -49,6 +54,17 @@ public class KafkaBroker implements Comparable<KafkaBroker> {
     this.reservedBytesOut = 0L;
     this.bytesInPerSecLimit = clusterConfig.getNetworkInLimitInBytes();
     this.bytesOutPerSecLimit = clusterConfig.getNetworkOutLimitInBytes();
+  }
+
+  public JsonElement toJson() {
+    // Return a JSON representation of a Kafka Broker.  Sadly, not everything can be trivially added.
+    JsonObject json = new JsonObject();
+    json.add("brokerId", gson.toJsonTree(brokerId));
+    json.add("brokerName", gson.toJsonTree(brokerName));
+    json.add("rackId", gson.toJsonTree(rackId));
+    json.add("bytesInPerSecLimit", gson.toJsonTree(bytesInPerSecLimit));
+    json.add("bytesOutPerSecLimit", gson.toJsonTree(bytesOutPerSecLimit));
+    return json;
   }
 
   public long getMaxBytesIn() {

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaCluster.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaCluster.java
@@ -8,6 +8,9 @@ import com.pinterest.doctorkafka.util.OutOfSyncReplica;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -103,6 +106,21 @@ public class KafkaCluster {
     } catch (Exception e) {
       LOG.error("Failed to read broker stats : {}", brokerStats, e);
     }
+  }
+
+  public JsonElement toJson() {
+    JsonObject json = new JsonObject();
+    JsonArray jsonBrokers = new JsonArray();
+    json.add("brokers", jsonBrokers);
+
+    List<KafkaBroker> result = new ArrayList<>();
+
+    synchronized (brokers) {
+      for (KafkaBroker broker : brokers.values()) {
+	  jsonBrokers.add(broker.toJson());
+      }
+    }
+    return json;
   }
 
   /**

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
@@ -30,6 +30,9 @@ import org.apache.zookeeper.data.ACL;
 import scala.Option;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
@@ -54,6 +57,7 @@ import java.util.stream.Collectors;
 public class KafkaClusterManager implements Runnable {
 
   private static final Logger LOG = LogManager.getLogger(KafkaClusterManager.class);
+  private static final Gson gson = new Gson();
   /**
    * The time-out for machine reboot etc.
    */
@@ -129,8 +133,30 @@ public class KafkaClusterManager implements Runnable {
     stopped = true;
   }
 
+  public JsonElement toJson() {
+    // Return a JSON representation of a Kafka Cluster.
+    JsonObject json = new JsonObject();
+    KafkaConsumer kafkaConsumer = KafkaUtils.getKafkaConsumer(zkUrl, securityProtocol, consumerConfigs);
+    json.addProperty("zkUrl", zkUrl);
+    json.add("bytesInLimit", gson.toJsonTree(bytesInLimit));
+    json.add("bytesOutLimit", gson.toJsonTree(bytesOutLimit));
+    json.add("underReplicatedPartitions", gson.toJsonTree(underReplicatedPartitions));
+    json.add("topicPartitionAssignments", gson.toJsonTree(topicPartitionAssignments));
+    json.add("kafkaCluster", gson.toJsonTree(kafkaCluster.toJson()));
+    json.add("topics", gson.toJsonTree(kafkaConsumer.listTopics()));
+    return json;
+  }
+
   public String getClusterName() {
     return clusterConfig.getClusterName();
+  }
+
+  public String getZkUrl() {
+    return zkUrl;
+  }
+
+  public Map<String, scala.collection.Map<Object, Seq<Object>>>  getTopicPartitionAssignments() {
+    return topicPartitionAssignments;
   }
 
   public int getClusterSize() {

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/errors/ClusterInfoError.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/errors/ClusterInfoError.java
@@ -1,0 +1,22 @@
+package com.pinterest.doctorkafka.errors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.lang.Exception;
+
+public class ClusterInfoError extends Exception {
+    String[] errors;
+
+    public ClusterInfoError() {
+        this.errors = new String[1];
+	this.errors[0] = "Unknown error";
+    }
+
+    public ClusterInfoError(String... errors) {
+        this.errors = new String[errors.length];
+        int i = 0;
+        for(String error : errors ) {
+            this.errors[i++] = error;
+        }
+    }
+}

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/DoctorKafkaInfoServlet.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/DoctorKafkaInfoServlet.java
@@ -3,10 +3,14 @@ package com.pinterest.doctorkafka.servlet;
 
 import com.pinterest.doctorkafka.KafkaClusterManager;
 import com.pinterest.doctorkafka.DoctorKafkaMain;
+import com.pinterest.doctorkafka.servlet.DoctorKafkaServletUtil;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.jetty.http.HttpStatus;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -14,26 +18,45 @@ import java.lang.management.ManagementFactory;
 import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-public class DoctorKafkaInfoServlet extends HttpServlet {
+public class DoctorKafkaInfoServlet extends DoctorKafkaServletUtil {
 
   private static final Logger LOG = LogManager.getLogger(DoctorKafkaInfoServlet.class);
+  private static final Gson gson = new Gson();
 
   @Override
-  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-      throws ServletException, IOException {
+  public void renderJSON(PrintWriter writer, Map<String, String> params) {
+    JsonObject json = new JsonObject();
+    json.add("version", gson.toJsonTree(getVersion()));
+    json.add("uptime", gson.toJsonTree(ManagementFactory.getRuntimeMXBean().getUptime() / 1000.0));
+    JsonArray jsonClusters = new JsonArray();
+    json.add("clusters", jsonClusters);
 
-    resp.setContentType("text/html");
-    resp.setStatus(HttpStatus.OK_200);
+    Collection<KafkaClusterManager> clusterManagers = DoctorKafkaMain.doctorKafka.getClusterManagers();
 
-    PrintWriter writer = resp.getWriter();
+    for (KafkaClusterManager clusterManager : clusterManagers) {
+      JsonObject cluster = new JsonObject();
+      cluster.add("clusterName", gson.toJsonTree(clusterManager.getClusterName()));
+      if (clusterManager.getCluster() != null) {
+	cluster.add("size", gson.toJsonTree(clusterManager.getClusterSize()));
+	cluster.add("urps", gson.toJsonTree(clusterManager.getUnderReplicatedPartitions().size()));
+      } else {
+	cluster.add("size", gson.toJsonTree(0));
+	cluster.add("urps", gson.toJsonTree(0));
+      }
+      jsonClusters.add(cluster);
+    }
+
+    writer.print(json);
+    
+  }
+  
+
+  @Override
+  public void renderHTML(PrintWriter writer, Map<String, String> params) {
     try {
       double jvmUpTimeInSeconds = ManagementFactory.getRuntimeMXBean().getUptime() / 1000.0;
-      String version = DoctorKafkaServletUtil.getVersion();
+      String version = getVersion();
       writer.print("<div>");
       writer.print("<p> Version: " + version + ", Uptime: " + jvmUpTimeInSeconds + " seconds </p>");
       writer.print("</div>");
@@ -45,7 +68,7 @@ public class DoctorKafkaInfoServlet extends HttpServlet {
       writer.print("<th> Maintenance Mode </th>");
       writer.print("<tbody>");
 
-      Map<String, String>  clustersHtml = new TreeMap<>();
+      Map<String, String> clustersHtml = new TreeMap<>();
       for (KafkaClusterManager clusterManager : clusterManagers) {
         String clusterName = clusterManager.getClusterName();
         String htmlStr;

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/DoctorKafkaServletUtil.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/DoctorKafkaServletUtil.java
@@ -6,6 +6,9 @@ import com.pinterest.doctorkafka.DoctorKafkaMain;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.http.HttpStatus;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,8 +21,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-public class DoctorKafkaServletUtil {
+public class DoctorKafkaServletUtil extends HttpServlet {
+  private static final Logger LOG = LogManager.getLogger(DoctorKafkaWebServer.class);
 
   public static String getVersion() {
     String versionString = "";
@@ -77,10 +85,12 @@ public class DoctorKafkaServletUtil {
   }
 
 
-  public static Map<String, String> parseQueryString(String queryString) {
+  private static Map<String, String> parseQueryString(String queryString) {
     Map<String, String> result = new HashMap<>();
-    Arrays.stream(queryString.split("&")).map(s -> s.split("=")).collect(toList())
-        .forEach(arr -> result.put(arr[0], arr[1]));
+    if (queryString != null) {
+      Arrays.stream(queryString.split("&")).map(s -> s.split("=")).collect(toList())
+	.forEach(arr -> result.put(arr[0], arr[1]));
+    }
     return result;
   }
 
@@ -101,4 +111,27 @@ public class DoctorKafkaServletUtil {
     }
     return result;
   }
+
+  public void renderJSON(PrintWriter writer, Map<String, String> params){};
+  public void renderHTML(PrintWriter writer, Map<String, String> params){};
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    LOG.info("Start working on get request");
+    resp.setStatus(HttpStatus.OK_200);
+
+    PrintWriter writer = resp.getWriter();
+    String contentType = req.getHeader("content-type");
+    String queryString = req.getQueryString();
+    Map<String, String> params = parseQueryString(queryString);
+    if (contentType != null && contentType == "application/json") {
+	resp.setContentType("application/json");
+        renderJSON(writer, params);
+    } else {
+      resp.setContentType("text/html");
+      renderHTML(writer, params);
+    }
+  }  
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/KafkaTopicStatsServlet.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/KafkaTopicStatsServlet.java
@@ -6,39 +6,71 @@ import com.pinterest.doctorkafka.KafkaCluster;
 import com.pinterest.doctorkafka.KafkaClusterManager;
 import com.pinterest.doctorkafka.replicastats.ReplicaStatsManager;
 import com.pinterest.doctorkafka.util.KafkaUtils;
+import com.pinterest.doctorkafka.errors.ClusterInfoError;
+import com.pinterest.doctorkafka.servlet.DoctorKafkaServletUtil;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.jetty.http.HttpStatus;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.TreeSet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-public class KafkaTopicStatsServlet extends HttpServlet {
+public class KafkaTopicStatsServlet extends DoctorKafkaServletUtil {
 
   private static final Logger LOG = LogManager.getLogger(KafkaTopicStatsServlet.class);
-
+  private static final Gson gson = new Gson();
+  
   @Override
-  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-      throws ServletException, IOException {
-
-    String queryString = req.getQueryString();
-    Map<String, String> params = DoctorKafkaServletUtil.parseQueryString(queryString);
+  public void renderJSON(PrintWriter writer, Map<String, String> params) {
     String clusterName = params.get("cluster");
     String topic = params.get("topic");
+    JsonArray json = new JsonArray();
 
-    resp.setStatus(HttpStatus.OK_200);
+    KafkaClusterManager clusterMananger =
+      DoctorKafkaMain.doctorKafka.getClusterManager(clusterName);
+    if (clusterMananger == null) {
+      ClusterInfoError error = new ClusterInfoError("Failed to find cluster manager for {}", clusterName);
+      writer.print(gson.toJson(error));
+      return;
+    }
 
-    PrintWriter writer = resp.getWriter();
     try {
-      DoctorKafkaServletUtil.printHeader(writer);
+      KafkaCluster cluster = clusterMananger.getCluster();
+      
+      TreeSet<TopicPartition> topicPartitions =
+        new TreeSet( new KafkaUtils.TopicPartitionComparator());
+      topicPartitions.addAll(cluster.topicPartitions.get(topic));
+
+      for (TopicPartition topicPartition : topicPartitions) {
+	double bytesInMax =
+          ReplicaStatsManager.getMaxBytesIn(cluster.zkUrl, topicPartition) / 1024.0 / 1024.0;
+	double bytesOutMax =
+          ReplicaStatsManager.getMaxBytesOut(cluster.zkUrl, topicPartition) / 1024.0 / 1024.0;
+
+	JsonObject jsonPartition = new JsonObject();
+	jsonPartition.add("bytesInMax", gson.toJsonTree(bytesInMax));
+	jsonPartition.add("bytesOutMax", gson.toJsonTree(bytesOutMax));
+	jsonPartition.add("partition", gson.toJsonTree(topicPartition.partition()));
+	json.add(jsonPartition);
+      }
+      writer.print(json);
+    } catch (Exception e) {
+      writer.print(gson.toJson(e));
+    }
+  }
+
+  @Override
+  public void renderHTML(PrintWriter writer, Map<String, String> params) {
+    String clusterName = params.get("cluster");
+    String topic = params.get("topic");
+    try {
+      printHeader(writer);
       writer.print("<div> <p><a href=\"/\">Home</a> > "
           + "<a href=\"/servlet/clusterinfo?name=" + clusterName + "\"> " + clusterName
           + "</a> > " + topic + "</p> </div>");
@@ -53,13 +85,12 @@ public class KafkaTopicStatsServlet extends HttpServlet {
       writer.print("<div> <h4> Cluster : " + clusterName + "</h4> </div>");
       KafkaCluster cluster = clusterMananger.getCluster();
       printTopicPartitionInfo(cluster, writer, topic);
-      DoctorKafkaServletUtil.printFooter(writer);
+      printFooter(writer);
 
     } catch (Exception e) {
       e.printStackTrace(writer);
     }
   }
-
 
   private void printTopicPartitionInfo(KafkaCluster cluster, PrintWriter writer, String topic) {
 

--- a/drkafka/src/test/java/com/pinterest/doctorkafka/ClusterInfoServletTest.java
+++ b/drkafka/src/test/java/com/pinterest/doctorkafka/ClusterInfoServletTest.java
@@ -1,0 +1,47 @@
+package com.pinterest.doctorkafka;
+
+import com.pinterest.doctorkafka.config.DoctorKafkaConfig;
+import com.pinterest.doctorkafka.servlet.ClusterInfoServlet;
+import kafka.cluster.Cluster;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.matchers.Any;
+import scala.Console;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class ClusterInfoServletTest extends Mockito {
+
+  @Test
+  public void clusterInfoJSONResponse() throws Exception {
+    String clusterName = "cluster1";
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    DoctorKafka mockDoctor = mock(DoctorKafka.class);
+    DoctorKafkaMain.doctorKafka = mockDoctor;
+    KafkaClusterManager clusterManager = mock(KafkaClusterManager.class);
+    DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.properties");
+    KafkaCluster cluster = new KafkaCluster(clusterName, config.getClusterConfigByName(clusterName));
+
+    when(mockDoctor.getClusterManager(clusterName)).thenReturn(clusterManager);
+    when(clusterManager.getCluster()).thenReturn(cluster);
+
+    // make sure we can see the response
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    // pretend our client asked for json
+    when(request.getQueryString()).thenReturn("name=" + clusterName);
+    when(request.getHeader("content-type")).thenReturn("application/json");
+    new ClusterInfoServlet().doGet(request, response);
+
+    String output = stringWriter.getBuffer().toString();
+    Console.println(output);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,13 @@
 			<artifactId>jackson-module-scala_2.12</artifactId>
 			<version>2.9.7</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+		<dependency>
+		  <groupId>org.mockito</groupId>
+		  <artifactId>mockito-core</artifactId>
+		  <version>2.10.0</version>
+		  <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>


### PR DESCRIPTION
This replaces #28 .  I messed up a rebase there and the PR is all wonky now.  This is much cleaner.

WIth this patch, the standard servlets respond to a Content-Header of "application/json" by returning JSON content instead of the usual HTML, which is a fairly standard convention for web applications.