### PR TITLE
PLAINTEXT is the default

### DIFF
--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
@@ -506,7 +506,8 @@ public class BrokerStatsRetriever {
       zkUrl = properties.getProperty(ZOOKEEPER_CONNECT);
       brokerStats.setZkUrl(zkUrl);
 
-      String securityProtocolStr = properties.getProperty(SECURITY_INTER_BROKER_PROTOCOL);
+      String securityProtocolStr = properties.containsKey(SECURITY_INTER_BROKER_PROTOCOL) ? properties.getProperty(SECURITY_INTER_BROKER_PROTOCOL)
+	                                                                                  : "PLAINTEXT";
       securityProtocol = Enum.valueOf(SecurityProtocol.class, securityProtocolStr);
 
       // log.dirs specifies the directories in which the log data is kept.


### PR DESCRIPTION
From the Kafka documentation, security.inter.broker.protocol has a default value of PLAINTEXT, so let's assume that's what it is for people who do not keep default values in their configuration files.