### PR TITLE
disable network stats computation in kafkastats

### DIFF
--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
@@ -647,37 +647,29 @@ public class BrokerStatsRetriever {
     brokerStats.setCpuUsage(cpuLoad);
     computeTopicPartitionReplicaCpuUsage(cpuLoad, brokerStats.getLeaderReplicaStats());
     
-    Map<String, NetworkStats> systemNetworkStats = getSystemNetworkStats();
-    NetworkStats networkStats = systemNetworkStats.get(primaryNetworkInterfaceName);
-    if (networkStats == null) {
-      brokerStats.setHasFailure(true);
-      return brokerStats;
-    }
-    computeNetworkStats(networkStats, brokerStats);
-    
     brokerStats.setHasFailure(false);
-    
     return brokerStats;
   }
   
   private void computeNetworkStats(NetworkStats networkStats, BrokerStats brokerStats) {
     if(this.currentNetworkStats == null) {
       this.currentNetworkStats = networkStats;
+    } else {
+      // take delta of timestamp
+      long deltaT = networkStats.getTimestamp() - currentNetworkStats.getTimestamp();
+      // convert to seconds
+      deltaT = deltaT / 1000;
+
+      if (deltaT > 0) {
+        long rxRate = networkStats.getRxBytes() - currentNetworkStats.getRxBytes();
+        long txRate = networkStats.getTxBytes() - currentNetworkStats.getTxBytes();
+        // per second average rate during the poll window
+        brokerStats.setSysBytesIn1MinRate(rxRate / deltaT);
+        brokerStats.setSysBytesOut1MinRate(txRate / deltaT);
+      }
+      // update the current for next poll
+      currentNetworkStats = networkStats;
     }
-    // take delta of timestamp
-    long deltaT = networkStats.getTimestamp() - currentNetworkStats.getTimestamp();
-    // convert to seconds
-    deltaT = deltaT / 1000; 
-    
-    long rxRate = networkStats.getRxBytes() - currentNetworkStats.getRxBytes();
-    long txRate = networkStats.getTxBytes() - currentNetworkStats.getTxBytes();
-    
-    // per second average rate during the poll window
-    brokerStats.setSysBytesIn1MinRate(rxRate/deltaT);
-    brokerStats.setSysBytesOut1MinRate(txRate/deltaT);
-    
-    // update the current for next poll
-    currentNetworkStats = networkStats;
   }
 
   public static class NetworkStats {


### PR DESCRIPTION
Disable network stats related computation that was introduced in  https://github.com/pinterest/doctorkafka/commit/2d6a8971b1babd82ff42d49421322dcbf7825bdf 
