### PR TITLE
Only call out to ec2metadata once per kafkastats execution

### DIFF
--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsReporter.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsReporter.java
@@ -1,6 +1,7 @@
 package com.pinterest.doctorkafka.stats;
 
 import com.pinterest.doctorkafka.BrokerStats;
+import com.pinterest.doctorkafka.stats.HostStats;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -28,6 +29,7 @@ public class BrokerStatsReporter implements Runnable {
   private KafkaAvroPublisher avroPublisher;
   private long pollingIntervalInSeconds;
   private String primaryNetworkInterfaceName;
+  private HostStats hostStats;
 
   public BrokerStatsReporter(String kafkaConfigPath, String host, String jmxPort,
                              KafkaAvroPublisher avroPublisher, long pollingIntervalInSeconds, String primaryNetworkInterfaceName) {
@@ -37,6 +39,7 @@ public class BrokerStatsReporter implements Runnable {
     this.avroPublisher = avroPublisher;
     this.pollingIntervalInSeconds = pollingIntervalInSeconds;
     this.primaryNetworkInterfaceName = primaryNetworkInterfaceName;
+    this.hostStats = new HostStats();
   }
 
 
@@ -52,7 +55,7 @@ public class BrokerStatsReporter implements Runnable {
 
   @Override
   public void run() {
-    BrokerStatsRetriever brokerStatsRetriever = new BrokerStatsRetriever(kafkaConfigPath, primaryNetworkInterfaceName);
+    BrokerStatsRetriever brokerStatsRetriever = new BrokerStatsRetriever(kafkaConfigPath, primaryNetworkInterfaceName, hostStats);
     try {
       BrokerStats stats = brokerStatsRetriever.retrieveBrokerStats(brokerHost, jmxPort);
       avroPublisher.publish(stats);

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/HostStats.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/HostStats.java
@@ -1,0 +1,100 @@
+package com.pinterest.doctorkafka.stats;
+
+import com.pinterest.doctorkafka.util.OperatorUtil;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+// None of this information should ever change
+public class HostStats {
+
+  private static final Logger LOG = LogManager.getLogger(HostStats.class);
+
+  private String availabilityZone = null;
+  private String instanceType = null;
+  private String amiId = null;
+  private String hostname = null;
+
+  public HostStats() {
+    String value = null;
+    BufferedReader input = null;
+    try {
+      Process process = Runtime.getRuntime().exec("ec2metadata");
+      input = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+      String outputLine;
+      while ((outputLine = input.readLine()) != null) {
+        String[] elements = outputLine.split(":");
+        if (elements.length != 2) {
+          continue;
+        }
+	value = elements[1].trim();
+        if (elements[0].equals("availability-zone")) {
+          availabilityZone = value;
+        } else if (elements[0].equals("instance-type")) {
+          instanceType = value;
+        } else if (elements[0].equals("ami-id")) {
+          amiId = value;
+        } else if (elements[0].equals("hostname")) { // This only works if the hostname is explicitly set in AWS
+          hostname = value;
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to get ec2 metadata", e);
+    } finally {
+      if (input != null) {
+        try {
+          input.close();
+        } catch (IOException e) {
+          LOG.error("Failed to close bufferReader", e);
+        }
+      }
+    }
+    // Not every Kafka cluster lives in AWS
+    if (hostname == null) {
+	hostname = OperatorUtil.getHostname();
+    }
+    LOG.info("set hostname to {}", hostname);
+  }
+
+  // getters
+  public String getAvailabilityZone() {
+    return availabilityZone;
+  }
+
+  public String getInstanceType() {
+    return instanceType;
+  }
+
+  public String getAmiId() {
+    return amiId;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+}


### PR DESCRIPTION
Fixes #84 

Extracts the constant host data acquisition from the run loop so it only happens once.