### PR TITLE
Dr. Kafka slow balancer

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafka.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafka.java
@@ -4,6 +4,7 @@ import com.pinterest.doctorkafka.config.DoctorKafkaClusterConfig;
 import com.pinterest.doctorkafka.config.DoctorKafkaConfig;
 import com.pinterest.doctorkafka.replicastats.BrokerStatsProcessor;
 import com.pinterest.doctorkafka.replicastats.ReplicaStatsManager;
+import com.pinterest.doctorkafka.util.KafkaUtils;
 import com.pinterest.doctorkafka.util.ZookeeperClient;
 
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -46,6 +47,13 @@ public class DoctorKafka {
     SecurityProtocol statsSecurityProtocol = drkafkaConf.getBrokerStatsConsumerSecurityProtocol();
     String actionReportTopic = drkafkaConf.getActionReportTopic();
     SecurityProtocol actionReportSecurityProtocol = drkafkaConf.getActionReportProducerSecurityProtocol();
+    
+    // Pre-warm consumers cache for clusters
+    for (String zkUrl : clusterZkUrls) {
+      DoctorKafkaClusterConfig clusterConf = drkafkaConf.getClusterConfigByZkUrl(zkUrl);
+      KafkaUtils.getKafkaConsumer(zkUrl, 
+          clusterConf.getSecurityProtocol(), clusterConf.getConsumerConfigurations());
+    }
 
     LOG.info("Start rebuilding the replica stats by reading the past 24 hours brokerstats");
     ReplicaStatsManager.readPastReplicaStats(brokerstatsZkurl, statsSecurityProtocol,

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaCluster.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaCluster.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -350,5 +351,21 @@ public class KafkaCluster {
       strBuilder.append(entry.getValue() + "\n");
     }
     return strBuilder.toString();
+  }
+
+  /**
+   * @param broker
+   * @return topic partition with highest In traffic
+   */
+  public List<TopicPartition> getHighestTrafficFollowerPartitionsForBroker(KafkaBroker broker) {
+    List<TopicPartition> sortedTopicByTraffic = new ArrayList<>(broker.getFollowerTopicPartitions());
+    sortedTopicByTraffic.sort(new Comparator<TopicPartition>() {
+
+      @Override
+      public int compare(TopicPartition o1, TopicPartition o2) {
+        return Double.compare(ReplicaStatsManager.getMaxBytesIn(zkUrl, o2), ReplicaStatsManager.getMaxBytesIn(zkUrl, o1));
+      }
+    });
+    return sortedTopicByTraffic;
   }
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaClusterConfig.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaClusterConfig.java
@@ -34,6 +34,7 @@ public class DoctorKafkaClusterConfig {
   private static final String SECURITY_PROTOCOL = "security.protocol";
   private static final String NOTIFICATION_EMAIL = "notification.email";
   private static final String NOTIFICATION_PAGER = "notificatino.pager";
+  private static final String SLOW_BALANCER = "slow_balancer.enabled";
 
   private static final int DEFAULT_DEADBROKER_REPLACEMENT_NO_STATS_SECONDS = 1200;
   private static final int DEFAULT_UNDER_REPLICTED_ALERT_IN_SECS = 7200;
@@ -64,6 +65,10 @@ public class DoctorKafkaClusterConfig {
       result = clusterConfiguration.getBoolean(ENABLE_WORLOAD_BALANCING);
     }
     return result;
+  }
+  
+  public boolean isSlowBalancerEnabled() {
+    return clusterConfiguration.getBoolean(SLOW_BALANCER, false);
   }
 
   public double getNetworkInLimitInMb() {

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/util/KafkaUtils.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/util/KafkaUtils.java
@@ -115,6 +115,10 @@ public class KafkaUtils {
     }
     return kafkaConsumers.get(key);
   }
+  
+  public static KafkaConsumer<?, ?> getCachedConsumer(String zkUrl) {
+    return kafkaConsumers.get(zkUrl);
+  }
 
   public static KafkaConsumer<?, ?> getKafkaConsumer(String zkUrl,
                                                String keyDeserializer, String valueDeserializer) {


### PR DESCRIPTION
**Purpose:**
Kafka cluster rebalancing when cluster is under heavy load can be very tricky. Slowly balancing the cluster might a an alternative to rebalance the cluster 1 Topic - Partition at a time.

**Implementation:**

- Adding a new method to create slow balancing plan: `KafkaClusterManager.getSlowBalancerFollowerReassignmentPlanInJson()`

- Update KafkaBroker to fix MaxOut bandwidth calculation (include replication traffic)
