### PR TITLE
Fix #18 duplicate reassignment

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -80,6 +80,7 @@
 			<artifactId>commons-validator</artifactId>
 			<version>1.6</version>
 		</dependency>
+		<!--Use aggregated junit-jupiter to fix previous mismatch of multiple junit dependencies-->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>

--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -82,14 +82,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.0.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.3.1</version>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.4.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -298,18 +292,6 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.1</version> <!-- Cannot use 2.20 - See http://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven -->
-				<dependencies>
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>1.0.3</version>
-					</dependency>
-					<dependency>
-						<groupId>org.junit.jupiter</groupId>
-						<artifactId>junit-jupiter-engine</artifactId>
-						<version>5.3.1</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
@@ -599,10 +599,9 @@ public class KafkaClusterManager implements Runnable {
       List<OutOfSyncReplica> outOfSyncReplicas) {
     Map<TopicPartition, Integer[]> replicasMap = new HashMap<>();
     boolean success = true;
-    PriorityQueue<KafkaBroker> brokerQueue;
+
+    PriorityQueue<KafkaBroker> brokerQueue = kafkaCluster.getBrokerQueue();
     for (OutOfSyncReplica oosReplica : outOfSyncReplicas) {
-      // rebuild broker queue each time to get up-to-date results
-      brokerQueue = kafkaCluster.getBrokerQueue();
       Map<Integer, KafkaBroker> replacedNodes =
           kafkaCluster.getAlternativeBrokers(brokerQueue, oosReplica);
       if (replacedNodes == null) {

--- a/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
+++ b/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
@@ -1,0 +1,117 @@
+package com.pinterest.doctorkafka;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.pinterest.doctorkafka.config.DoctorKafkaClusterConfig;
+import com.pinterest.doctorkafka.config.DoctorKafkaConfig;
+import com.pinterest.doctorkafka.replicastats.ReplicaStatsManager;
+import com.pinterest.doctorkafka.util.OutOfSyncReplica;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.UniformReservoir;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+class KafkaClusterTest {
+  private static final String TOPIC = "test_topic";
+  private static final String ZOOKEEPER_URL = "zk001/cluster1";
+
+  @Test
+  void getAlternativeBrokersDuplicateReassignmentTest() throws Exception{
+    DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.properties");
+    DoctorKafkaClusterConfig doctorKafkaClusterConfig = config.getClusterConfigByName("cluster1");
+
+    ConcurrentMap<String, ConcurrentMap<TopicPartition, Histogram>> oldBytesInStats = ReplicaStatsManager.bytesInStats;
+    ConcurrentMap<String, ConcurrentMap<TopicPartition, Histogram>> oldBytesOutStats = ReplicaStatsManager.bytesOutStats;
+
+    TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+
+    ConcurrentMap<String, ConcurrentMap<TopicPartition, Histogram>> testBytesInStats = new ConcurrentHashMap<>();
+    ConcurrentMap<String, ConcurrentMap<TopicPartition, Histogram>> testBytesOutStats = new ConcurrentHashMap<>();
+    ConcurrentMap<TopicPartition, Histogram> testBytesInHistograms = new ConcurrentHashMap<>();
+    ConcurrentMap<TopicPartition, Histogram> testBytesOutHistograms = new ConcurrentHashMap<>();
+    Histogram inHist = new Histogram(new UniformReservoir());
+    Histogram outHist = new Histogram(new UniformReservoir());
+
+    inHist.update(0);
+    outHist.update(0);
+
+    testBytesInHistograms.put(topicPartition, inHist);
+    testBytesOutHistograms.put(topicPartition, outHist);
+
+    testBytesInStats.put(ZOOKEEPER_URL, testBytesInHistograms);
+    testBytesOutStats.put(ZOOKEEPER_URL, testBytesOutHistograms);
+
+    ReplicaStatsManager.bytesInStats = testBytesInStats;
+    ReplicaStatsManager.bytesOutStats = testBytesOutStats;
+
+    KafkaCluster kafkaCluster = new KafkaCluster(ZOOKEEPER_URL, doctorKafkaClusterConfig);
+
+    Node[] nodes = new Node[]{
+        new Node(0, "test00", 9092),
+        new Node(1, "test01", 9092),
+        new Node(2, "test02", 9092),
+        new Node(3, "test03", 9092),
+        new Node(4, "test04", 9092)
+    };
+
+    Node leader = nodes[0];
+    Node[] replicas = new Node[]{
+        nodes[0],
+        nodes[1],
+        nodes[2]
+    };
+
+    Node[] isrs = new Node[]{
+        nodes[0]
+    };
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, 0, leader, replicas, isrs);
+    OutOfSyncReplica oosReplica = new OutOfSyncReplica(partitionInfo);
+    oosReplica.replicaBrokers = Arrays.asList(new Integer[]{0,1,2});
+
+
+    KafkaBroker[] brokers = new KafkaBroker[]{
+        new KafkaBroker(doctorKafkaClusterConfig, 0),
+        new KafkaBroker(doctorKafkaClusterConfig, 1),
+        new KafkaBroker(doctorKafkaClusterConfig, 2),
+        new KafkaBroker(doctorKafkaClusterConfig, 3),
+        new KafkaBroker(doctorKafkaClusterConfig, 4)
+    };
+
+    // setting the reservedBytesIn for priority queue comparisons
+    brokers[4].reserveInBoundBandwidth(topicPartition, 10);
+    brokers[4].reserveOutBoundBandwidth(topicPartition, 10);
+
+    PriorityQueue<KafkaBroker> brokerQueue = new PriorityQueue<>();
+
+    for ( KafkaBroker broker : brokers){
+      brokerQueue.add(broker);
+    }
+
+    int beforeSize = brokerQueue.size();
+
+    /**
+     * Since the BytesInStats/BytesOutStats are not set,
+     * getMaxBytesIn() and getMaxBytesOut() will return 0 for each broker,
+     * so brokerQueue won't change
+     **/
+    Map<Integer, KafkaBroker> altBrokers = kafkaCluster.getAlternativeBrokers(brokerQueue, oosReplica);
+
+    assertNotNull(altBrokers);
+    assertNull(altBrokers.get(0));
+    assertNotEquals(altBrokers.get(1), altBrokers.get(2));
+    assertEquals(beforeSize, brokerQueue.size());
+
+    ReplicaStatsManager.bytesInStats = oldBytesInStats;
+    ReplicaStatsManager.bytesOutStats = oldBytesOutStats;
+  }
+
+}


### PR DESCRIPTION
Addressing #18
Duplicate reassignment will happen when multiple outOfSyncReplicas exist and target broker is still least used broker.
Creating the broker queue each time so we don't need to deal with recovering the brokerQueue for next outOfSyncReplica