### PR TITLE
Add simple logic locality-awareness reassignments

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaClusterConfig.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaClusterConfig.java
@@ -34,6 +34,7 @@ public class DoctorKafkaClusterConfig {
   private static final String SECURITY_PROTOCOL = "security.protocol";
   private static final String NOTIFICATION_EMAIL = "notification.email";
   private static final String NOTIFICATION_PAGER = "notificatino.pager";
+  private static final String ENABLE_RACK_AWARENESS = "rack_awareness.enabled";
 
   private static final int DEFAULT_DEADBROKER_REPLACEMENT_NO_STATS_SECONDS = 1200;
   private static final int DEFAULT_UNDER_REPLICTED_ALERT_IN_SECS = 7200;
@@ -134,5 +135,13 @@ public class DoctorKafkaClusterConfig {
 
   public String getNotificationPager() {
     return clusterConfiguration.getString(NOTIFICATION_PAGER, "");
+  }
+
+  public boolean enabledRackAwareness(){
+    boolean result = false;
+    if (clusterConfiguration.containsKey(ENABLE_RACK_AWARENESS)){
+      result = clusterConfiguration.getBoolean(ENABLE_RACK_AWARENESS);
+    }
+    return result;
   }
 }

--- a/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
+++ b/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
@@ -11,15 +11,42 @@ import com.pinterest.doctorkafka.util.OutOfSyncReplica;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 class KafkaClusterTest {
   private static final String TOPIC = "test_topic";
-  private static final String ZOOKEEPER_URL = "zk001/cluster1";
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, 0);
+  private static final String[] LOCALITIES = new String[]{"LOCALITY_0","LOCALITY_1","LOCALITY_2"};
+  private static final Node[] nodes = new Node[]{
+      new Node(0, "test00", 9092),
+      new Node(1, "test01", 9092),
+      new Node(2, "test02", 9092),
+      new Node(3, "test03", 9092),
+      new Node(4, "test04", 9092),
+      new Node(5, "test05", 9092),
+      new Node(6, "test06", 9092)
+  };
+  private static final String CLUSTER_NAME = "cluster1";
+  private static DoctorKafkaClusterConfig doctorKafkaClusterConfig;
+  private static String zookeeper_url;
+
+  @BeforeAll
+  static void setup() throws Exception {
+    DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.properties");
+    doctorKafkaClusterConfig = config.getClusterConfigByName(CLUSTER_NAME);
+    zookeeper_url = doctorKafkaClusterConfig.getZkUrl();
+  }
 
   /**
    * This test assures that getAlternativeBrokers does not return a many-to-one reassignment
@@ -32,21 +59,10 @@ class KafkaClusterTest {
     ReplicaStatsManager mockReplicaStatsManager = mock(ReplicaStatsManager.class);
     TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
 
-    when(mockReplicaStatsManager.getMaxBytesIn(ZOOKEEPER_URL, topicPartition)).thenReturn(0L);
-    when(mockReplicaStatsManager.getMaxBytesOut(ZOOKEEPER_URL, topicPartition)).thenReturn(0L);
+    when(mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, topicPartition)).thenReturn(1L);
+    when(mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, topicPartition)).thenReturn(0L);
 
-    DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.properties");
-    DoctorKafkaClusterConfig doctorKafkaClusterConfig = config.getClusterConfigByName("cluster1");
-
-    KafkaCluster kafkaCluster = new KafkaCluster(ZOOKEEPER_URL, doctorKafkaClusterConfig, mockReplicaStatsManager);
-
-    Node[] nodes = new Node[]{
-        new Node(0, "test00", 9092),
-        new Node(1, "test01", 9092),
-        new Node(2, "test02", 9092),
-        new Node(3, "test03", 9092),
-        new Node(4, "test04", 9092)
-    };
+    KafkaCluster kafkaCluster = new KafkaCluster(zookeeper_url, doctorKafkaClusterConfig, mockReplicaStatsManager);
 
     Node leader = nodes[0];
     Node[] replicas = new Node[]{
@@ -64,33 +80,49 @@ class KafkaClusterTest {
 
 
     KafkaBroker[] brokers = new KafkaBroker[]{
-        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager,  0),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 0),
         new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 1),
         new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 2),
         new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 3),
         new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 4)
     };
 
+    Set<TopicPartition> replicaSet = new HashSet<>();
+    replicaSet.add(topicPartition);
+
+    for ( Node node : replicas ) {
+      brokers[node.id()].setFollowerReplicas(replicaSet);
+    }
+
+    brokers[leader.id()].setLeaderReplicas(replicaSet);
+
     // setting the reservedBytesIn for priority queue comparisons
-    brokers[4].reserveInBoundBandwidth(topicPartition, 10);
-    brokers[4].reserveOutBoundBandwidth(topicPartition, 10);
+    brokers[4].reserveBandwidth(TOPIC_PARTITION, 10, 10);
 
     PriorityQueue<KafkaBroker> brokerQueue = new PriorityQueue<>();
 
-    for ( KafkaBroker broker : brokers){
-      brokerQueue.add(broker);
-    }
+    brokerQueue.addAll(Arrays.asList((brokers)));
 
     int beforeSize = brokerQueue.size();
+
+    double inBoundReq = mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, topicPartition);
+    double outBoundReq = mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, topicPartition);
+    int preferredBroker = oosReplica.replicaBrokers.get(0);
 
     /*
      * getMaxBytesIn() and getMaxBytesOut() will return 0 for each broker,
      * so the ordering of the brokers will not change after reassignment
      */
-    Map<Integer, KafkaBroker> altBrokers = kafkaCluster.getAlternativeBrokers(brokerQueue, oosReplica);
+    Map<Integer, KafkaBroker> altBrokers = kafkaCluster.getAlternativeBrokers(
+        brokerQueue,
+        oosReplica,
+        inBoundReq,
+        outBoundReq,
+        preferredBroker
+    );
 
-    verify(mockReplicaStatsManager).getMaxBytesIn(ZOOKEEPER_URL, topicPartition);
-    verify(mockReplicaStatsManager).getMaxBytesOut(ZOOKEEPER_URL, topicPartition);
+    verify(mockReplicaStatsManager, atLeast(2)).getMaxBytesIn(zookeeper_url, topicPartition);
+    verify(mockReplicaStatsManager, atLeast(2)).getMaxBytesOut(zookeeper_url, topicPartition);
 
     // There should be a valid reassignment for this scenario
     assertNotNull(altBrokers);
@@ -100,6 +132,321 @@ class KafkaClusterTest {
     assertNotEquals(altBrokers.get(1), altBrokers.get(2));
     // The broker queue should contain the same amount of brokers
     assertEquals(beforeSize, brokerQueue.size());
+  }
+
+  @Test
+  void testLocalityAwareReassignments() throws Exception {
+    ReplicaStatsManager mockReplicaStatsManager = mock(ReplicaStatsManager.class);
+    TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+
+    when(mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, topicPartition)).thenReturn(0L);
+    when(mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, topicPartition)).thenReturn(0L);
+
+    DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.properties");
+    DoctorKafkaClusterConfig doctorKafkaClusterConfig = config.getClusterConfigByName("cluster1");
+
+    KafkaCluster kafkaCluster = new KafkaCluster(zookeeper_url, doctorKafkaClusterConfig, mockReplicaStatsManager);
+
+
+    Node leader = nodes[0];
+    Node[] replicas = new Node[]{
+        nodes[0],
+        nodes[1],
+        nodes[2],
+    };
+
+    Node[] isrs = new Node[]{
+        nodes[0]
+    };
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, 0, leader, replicas, isrs);
+    OutOfSyncReplica oosReplica = new OutOfSyncReplica(partitionInfo);
+    oosReplica.replicaBrokers = Arrays.asList(new Integer[]{0,1,2});
+
+
+    KafkaBroker[] brokers = new KafkaBroker[]{
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 0),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 1),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 2),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 3),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 4),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 5),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 6)
+    };
+
+    for ( KafkaBroker broker : brokers ){
+      BrokerStats bs = new BrokerStats();
+      bs.setTimestamp(System.currentTimeMillis());
+      broker.setLatestStats(bs);
+      kafkaCluster.brokers.put(broker.id(), broker);
+    }
+
+    Set<TopicPartition> replicaSet = new HashSet<>();
+    replicaSet.add(topicPartition);
+
+    for ( Node node : replicas ) {
+      brokers[node.id()].setFollowerReplicas(replicaSet);
+    }
+
+    brokers[leader.id()].setLeaderReplicas(replicaSet);
+
+    // a list of assignments of localities to brokers with the same size as LOCALITIES
+    List<List<Integer>> testLocalityAssignments = Arrays.asList(
+        Arrays.asList(0, 3),
+        Arrays.asList(1, 2, 4, 5),
+        Arrays.asList(6)
+    );
+
+    for (int localityId = 0; localityId < testLocalityAssignments.size(); localityId++) {
+      for(int brokerId : testLocalityAssignments.get(localityId)){
+        brokers[brokerId].setRackId(LOCALITIES[localityId]);
+      }
+    }
+
+    // setting the reservedBytesIn for priority queue comparisons
+    brokers[4].reserveBandwidth(TOPIC_PARTITION, 10, 10);
+    brokers[5].reserveBandwidth(TOPIC_PARTITION, 5, 5);
+
+    Map<String, PriorityQueue<KafkaBroker>> brokerLocalityMap =
+        kafkaCluster.getBrokerQueueByLocality();
+    Map<OutOfSyncReplica, Map <Integer, String>> reassignmentToLocalityFailures = new HashMap<>();
+
+    for ( int localityId = 0; localityId < testLocalityAssignments.size(); localityId++) {
+      Collection<Integer> expectedAssignments = testLocalityAssignments.get(localityId);
+      Collection<KafkaBroker> actualAssignments = brokerLocalityMap.get(LOCALITIES[localityId]);
+      // size check
+      assertEquals(expectedAssignments.size(),actualAssignments.size());
+      // element check
+      assertTrue(actualAssignments
+          .stream()
+          .map(broker -> broker.id())
+          .collect(Collectors.toList())
+          .containsAll(expectedAssignments));
+    }
+
+    double inBoundReq = mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, oosReplica.topicPartition);
+    double outBoundReq = mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, oosReplica.topicPartition);
+    int preferredBroker = oosReplica.replicaBrokers.get(0);
+
+    // Test getAlternativeBrokersByLocality,
+    // brokers 1 & 2 are out of sync
+    // brokers 3 & 6 should be skipped even though they have the least utilization since they are not
+    // within the same locality as brokers 1 & 2
+
+    Map<Integer, KafkaBroker> localityReassignments =
+        kafkaCluster.getAlternativeBrokersByLocality(
+            brokerLocalityMap,
+            oosReplica,
+            inBoundReq,
+            outBoundReq,
+            preferredBroker
+        );
+
+    verify(mockReplicaStatsManager,atLeast(2)).getMaxBytesIn(zookeeper_url, topicPartition);
+    verify(mockReplicaStatsManager,atLeast(2)).getMaxBytesIn(zookeeper_url, topicPartition);
+    assertEquals(2, localityReassignments.size());
+    assertEquals(brokers[5], localityReassignments.get(1));
+    assertEquals(brokers[4], localityReassignments.get(2));
+
+    // check if the invariants are maintained after reassignment
+    for ( int localityId = 0; localityId < testLocalityAssignments.size(); localityId++) {
+      Collection<Integer> expectedAssignments = testLocalityAssignments.get(localityId);
+      Collection<KafkaBroker> actualAssignments = brokerLocalityMap.get(LOCALITIES[localityId]);
+      // size check
+      assertEquals(expectedAssignments.size(),actualAssignments.size());
+      // element check
+      assertTrue(actualAssignments
+          .stream()
+          .map(broker -> broker.id())
+          .collect(Collectors.toList())
+          .containsAll(expectedAssignments));
+    }
+
+  }
+
+  @Test
+  void testNonLocalityAwareReassignments() throws Exception {
+    ReplicaStatsManager mockReplicaStatsManager = mock(ReplicaStatsManager.class);
+    TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+
+    when(mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, topicPartition)).thenReturn(0L);
+    when(mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, topicPartition)).thenReturn(0L);
+
+    DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.properties");
+    DoctorKafkaClusterConfig doctorKafkaClusterConfig = config.getClusterConfigByName("cluster1");
+
+    KafkaCluster kafkaCluster = new KafkaCluster(zookeeper_url, doctorKafkaClusterConfig, mockReplicaStatsManager);
+
+    Node leader = nodes[0];
+    Node[] replicas = new Node[]{
+        nodes[0],
+        nodes[1],
+        nodes[2]
+    };
+
+    Node[] isrs = new Node[]{
+        nodes[0]
+    };
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, 0, leader, replicas, isrs);
+    OutOfSyncReplica oosReplica = new OutOfSyncReplica(partitionInfo);
+    oosReplica.replicaBrokers = Arrays.asList(new Integer[]{0,1,2});
+
+
+    KafkaBroker[] brokers = new KafkaBroker[]{
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 0),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 1),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 2),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 3),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 4),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 5),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 6)
+    };
+
+    for ( KafkaBroker broker : brokers ){
+      BrokerStats bs = new BrokerStats();
+      bs.setTimestamp(System.currentTimeMillis());
+      broker.setLatestStats(bs);
+      kafkaCluster.brokers.put(broker.id(), broker);
+    }
+
+    Set<TopicPartition> replicaSet = new HashSet<>();
+    replicaSet.add(topicPartition);
+
+    for ( Node node : replicas ) {
+      brokers[node.id()].setFollowerReplicas(replicaSet);
+    }
+
+    brokers[leader.id()].setLeaderReplicas(replicaSet);
+
+    // setting the reservedBytesIn for priority queue comparisons
+    brokers[4].reserveBandwidth(TOPIC_PARTITION, 10, 10);
+    brokers[5].reserveBandwidth(TOPIC_PARTITION, 5, 5);
+    brokers[6].reserveBandwidth(TOPIC_PARTITION, 2, 2);
+
+    Map<String, PriorityQueue<KafkaBroker>> brokerLocalityMap =
+        kafkaCluster.getBrokerQueueByLocality();
+    Map<OutOfSyncReplica, Map <Integer, String>> reassignmentToLocalityFailures = new HashMap<>();
+
+    assertEquals(brokers.length, brokerLocalityMap.get(null).size());
+    assertTrue(brokerLocalityMap.get(null).containsAll(Arrays.asList(brokers)));
+
+    double inBoundReq = mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, oosReplica.topicPartition);
+    double outBoundReq = mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, oosReplica.topicPartition);
+    int preferredBroker = oosReplica.replicaBrokers.get(0);
+
+    // Test getAlternativeBrokersByLocality,
+    // brokers 1 & 2 are out of sync
+    // brokers 3 & 6 are used because they have the lowest utilization
+
+    Map<Integer, KafkaBroker> localityReassignments =
+        kafkaCluster.getAlternativeBrokersByLocality(
+            brokerLocalityMap,
+            oosReplica,
+            inBoundReq,
+            outBoundReq,
+            preferredBroker
+        );
+
+    verify(mockReplicaStatsManager,atLeast(2)).getMaxBytesIn(zookeeper_url, topicPartition);
+    verify(mockReplicaStatsManager,atLeast(2)).getMaxBytesIn(zookeeper_url, topicPartition);
+    assertEquals(2, localityReassignments.size());
+    assertEquals(brokers[3], localityReassignments.get(1));
+    assertEquals(brokers[6], localityReassignments.get(2));
+  }
+
+  @Test
+  void testLocalityAwareReassignmentsFailure() throws Exception {
+    ReplicaStatsManager mockReplicaStatsManager = mock(ReplicaStatsManager.class);
+    TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+
+    // set to 20MB
+    when(mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, topicPartition)).thenReturn(20*1024*1024L);
+    when(mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, topicPartition)).thenReturn(0L);
+
+    DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.properties");
+    DoctorKafkaClusterConfig doctorKafkaClusterConfig = config.getClusterConfigByName("cluster1");
+
+    KafkaCluster kafkaCluster = new KafkaCluster(zookeeper_url, doctorKafkaClusterConfig, mockReplicaStatsManager);
+
+    Node leader = nodes[0];
+    Node[] replicas = new Node[]{
+        nodes[0],
+        nodes[1],
+        nodes[2],
+    };
+
+    Node[] isrs = new Node[]{
+        nodes[0]
+    };
+    PartitionInfo partitionInfo = new PartitionInfo(TOPIC, 0, leader, replicas, isrs);
+    OutOfSyncReplica oosReplica = new OutOfSyncReplica(partitionInfo);
+    oosReplica.replicaBrokers = Arrays.asList(new Integer[]{0,1,2});
+
+
+    KafkaBroker[] brokers = new KafkaBroker[]{
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 0),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 1),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 2),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 3),
+        new KafkaBroker(doctorKafkaClusterConfig, mockReplicaStatsManager, 4)
+    };
+
+    for ( KafkaBroker broker : brokers ){
+      BrokerStats bs = new BrokerStats();
+      bs.setTimestamp(System.currentTimeMillis());
+      broker.setLatestStats(bs);
+      kafkaCluster.brokers.put(broker.id(), broker);
+    }
+
+    Set<TopicPartition> replicaSet = new HashSet<>();
+    replicaSet.add(topicPartition);
+
+    for ( Node node : replicas ) {
+      brokers[node.id()].setFollowerReplicas(replicaSet);
+    }
+
+    brokers[leader.id()].setLeaderReplicas(replicaSet);
+
+    // a list of assignments of localities to brokers with the same size as LOCALITIES
+    List<List<Integer>> testLocalityAssignments = Arrays.asList(
+        Arrays.asList(0),
+        Arrays.asList(1, 3),
+        Arrays.asList(2, 4)
+    );
+
+    for (int localityId = 0; localityId < testLocalityAssignments.size(); localityId++) {
+      for(int brokerId : testLocalityAssignments.get(localityId)){
+        brokers[brokerId].setRackId(LOCALITIES[localityId]);
+      }
+    }
+
+    // setting the reservedBytesIn for priority queue comparisons
+    brokers[4].reserveBandwidth(TOPIC_PARTITION, 20*1024*1024, 10);
+
+    Map<String, PriorityQueue<KafkaBroker>> brokerLocalityMap =
+        kafkaCluster.getBrokerQueueByLocality();
+    Map<OutOfSyncReplica, Map <Integer, String>> reassignmentToLocalityFailures = new HashMap<>();
+
+    double inBoundReq = mockReplicaStatsManager.getMaxBytesIn(zookeeper_url, oosReplica.topicPartition);
+    double outBoundReq = mockReplicaStatsManager.getMaxBytesOut(zookeeper_url, oosReplica.topicPartition);
+    int preferredBroker = oosReplica.replicaBrokers.get(0);
+
+    // Test getAlternativeBrokersByLocality,
+    // brokers 1 & 2 are out of sync
+    // assignment fails since not enough bandwidth to migrate from 2 -> 4
+
+    Map<Integer, KafkaBroker> localityReassignments =
+        kafkaCluster.getAlternativeBrokersByLocality(
+            brokerLocalityMap,
+            oosReplica,
+            inBoundReq,
+            outBoundReq,
+            preferredBroker
+        );
+
+    verify(mockReplicaStatsManager,atLeast(2)).getMaxBytesIn(zookeeper_url, topicPartition);
+    verify(mockReplicaStatsManager,atLeast(2)).getMaxBytesIn(zookeeper_url, topicPartition);
+    assertNull(localityReassignments);
+
   }
 
 }


### PR DESCRIPTION
This is the first part for locality-aware reassignments using rackId/availability zone info. Currently it will not failover to other localities nor will it balance replicas throughout the localities. These issues will be issued afterwards.