### PR TITLE
Add option to disable restart

### DIFF
--- a/drkafka/config/doctorkafka.properties
+++ b/drkafka/config/doctorkafka.properties
@@ -69,6 +69,9 @@ doctorkafka.action.producer.ssl.truststore.type=JKS
 # [required] doctorkafka web port
 doctorkafka.web.port=8080
 
+# [optional] disable doctorkafka service restart
+doctorkafka.restart.disabled=false
+
 # [required] doctorkafka service restart interval
 doctorkafka.restart.interval.seconds=86400
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
@@ -57,8 +57,10 @@ public class DoctorKafkaMain extends Application<DoctorKafkaAppConfig> {
 
     ReplicaStatsManager.config = new DoctorKafkaConfig(configuration.getConfig());
 
-    operatorWatcher = new DoctorKafkaWatcher(ReplicaStatsManager.config.getRestartIntervalInSeconds());
-    operatorWatcher.start();
+    if (ReplicaStatsManager.config.getRestartDisabled()){
+      operatorWatcher = new DoctorKafkaWatcher(ReplicaStatsManager.config.getRestartIntervalInSeconds());
+      operatorWatcher.start();
+    }
 
     configureServerRuntime(configuration, ReplicaStatsManager.config);
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
@@ -57,7 +57,7 @@ public class DoctorKafkaMain extends Application<DoctorKafkaAppConfig> {
 
     ReplicaStatsManager.config = new DoctorKafkaConfig(configuration.getConfig());
 
-    if (ReplicaStatsManager.config.getRestartDisabled()){
+    if (!ReplicaStatsManager.config.getRestartDisabled()){
       operatorWatcher = new DoctorKafkaWatcher(ReplicaStatsManager.config.getRestartIntervalInSeconds());
       operatorWatcher.start();
     }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaConfig.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaConfig.java
@@ -35,6 +35,7 @@ public class DoctorKafkaConfig {
       "action.broker_replacement.interval.seconds";
   private static final String BROKER_REPLACEMENT_COMMAND = "action.broker_replacement.command";
   private static final String OSTRICH_PORT = "ostrich.port";
+  private static final String RESTART_DISABLE = "restart.disabled";
   private static final String RESTART_INTERVAL_SECONDS = "restart.interval.seconds";
   private static final String DOCTORKAFKA_ZKURL = "zkurl";
   private static final String TSD_HOSTPORT = "tsd.hostport";
@@ -207,5 +208,9 @@ public class DoctorKafkaConfig {
   public String[] getAlertEmails() {
     String emailsStr = drkafkaConfiguration.getString(ALERT_EMAILS);
     return emailsStr.split(",");
+  }
+
+  public boolean getRestartDisabled(){
+    return drkafkaConfiguration.getBoolean(RESTART_DISABLE, false);
   }
 }


### PR DESCRIPTION
Adding a configuration to disable the restarting doctorkafka, this option defaults to false, i.e. restart is on by default.