### PR TITLE
Added heartbeat metric and a few other metric-related fixes

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafka.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafka.java
@@ -33,6 +33,8 @@ public class DoctorKafka {
 
   private ZookeeperClient zookeeperClient = null;
 
+  private DoctorKafkaHeartbeat heartbeat = null;
+
   public DoctorKafka(DoctorKafkaConfig drkafkaConf) {
     this.drkafkaConf = drkafkaConf;
     this.clusterZkUrls = drkafkaConf.getClusterZkUrls();
@@ -72,11 +74,15 @@ public class DoctorKafka {
       clusterManager.start();
       LOG.info("Starting cluster manager for " + clusterZkUrl);
     }
+
+    heartbeat = new DoctorKafkaHeartbeat();
+    heartbeat.start();
   }
 
   public void stop() {
     brokerStatsProcessor.stop();
     zookeeperClient.close();
+    heartbeat.stop();
     for (KafkaClusterManager clusterManager : clusterManagers.values()) {
       clusterManager.stop();
     }
@@ -97,4 +103,5 @@ public class DoctorKafka {
   public List<String> getClusterNames() {
     return new ArrayList<>(clusterManagers.keySet());
   }
+
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaHeartbeat.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaHeartbeat.java
@@ -1,0 +1,32 @@
+package com.pinterest.doctorkafka;
+
+import com.pinterest.doctorkafka.util.OpenTsdbMetricConverter;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class DoctorKafkaHeartbeat implements Runnable {
+  private static final int HEARTBEAT_INTERVAL_IN_SECONDS = 60;
+  public ScheduledExecutorService heartbeatExecutor;
+
+  DoctorKafkaHeartbeat() {
+    heartbeatExecutor = Executors.newSingleThreadScheduledExecutor(
+        new ThreadFactoryBuilder().setNameFormat("Heartbeat").build());
+  }
+
+  public void start() {
+    heartbeatExecutor.scheduleAtFixedRate(this, 0, HEARTBEAT_INTERVAL_IN_SECONDS, TimeUnit.SECONDS);
+  }
+
+  public void stop() {
+    heartbeatExecutor.shutdown();
+  }
+
+  @Override
+  public void run() {
+    OpenTsdbMetricConverter.gauge(DoctorKafkaMetrics.DOCTORKAFKA_SERVICE_RUNNING, 1.0);
+  }
+}

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
@@ -21,7 +21,6 @@ import com.pinterest.doctorkafka.servlet.DoctorKafkaInfoServlet;
 import com.pinterest.doctorkafka.servlet.KafkaTopicStatsServlet;
 import com.pinterest.doctorkafka.servlet.UnderReplicatedPartitionsServlet;
 import com.pinterest.doctorkafka.util.OperatorUtil;
-import com.pinterest.doctorkafka.DoctorKafkaWatcher;
 
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
@@ -128,7 +127,7 @@ public class DoctorKafkaMain extends Application<DoctorKafkaAppConfig> {
       throw new NoSuchElementException(
           String.format("Key '%s' does not map to an existing object!", OSTRICH_PORT));
     } else {
-      OperatorUtil.startOstrichService(tsdHostPort, ostrichPort);
+      OperatorUtil.startOstrichService("doctorkafka", tsdHostPort, ostrichPort);
     }
   }
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMetrics.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMetrics.java
@@ -3,6 +3,7 @@ package com.pinterest.doctorkafka;
 public class DoctorKafkaMetrics {
 
   public static final String HANDLE_URP_FAILURE = "doctorkafka.failure.handle_under_replication";
-
   public static final String BROKERSTATS_MESSAGES = "doctorkafka.brokerstats.messages";
+  public static final String DOCTORKAFKA_SERVICE_RUNNING = "doctorkafka.service.running";
+  public static final String MESSAGE_DESERIALIZE_ERROR = "doctorkafka.message.decode.error";
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/replicastats/BrokerStatsProcessor.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/replicastats/BrokerStatsProcessor.java
@@ -1,6 +1,7 @@
 package com.pinterest.doctorkafka.replicastats;
 
 import com.pinterest.doctorkafka.BrokerStats;
+import com.pinterest.doctorkafka.DoctorKafka;
 import com.pinterest.doctorkafka.DoctorKafkaMetrics;
 import com.pinterest.doctorkafka.util.OpenTsdbMetricConverter;
 import com.pinterest.doctorkafka.util.OperatorUtil;
@@ -72,6 +73,7 @@ public class BrokerStatsProcessor implements Runnable {
             BrokerStats brokerStats = OperatorUtil.deserializeBrokerStats(record);
             if (brokerStats == null || brokerStats.getName() == null) {
               // ignore the messages that the operator fails to deserialize
+              OpenTsdbMetricConverter.incr(DoctorKafkaMetrics.MESSAGE_DESERIALIZE_ERROR, 1);
               continue;
             }
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/replicastats/PastReplicaStatsProcessor.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/replicastats/PastReplicaStatsProcessor.java
@@ -1,7 +1,9 @@
 package com.pinterest.doctorkafka.replicastats;
 
 import com.pinterest.doctorkafka.BrokerStats;
+import com.pinterest.doctorkafka.DoctorKafkaMetrics;
 import com.pinterest.doctorkafka.util.KafkaUtils;
+import com.pinterest.doctorkafka.util.OpenTsdbMetricConverter;
 import com.pinterest.doctorkafka.util.OperatorUtil;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -77,6 +79,7 @@ public class PastReplicaStatsProcessor implements Runnable {
         for (ConsumerRecord<byte[], byte[]> record : records) {
           BrokerStats brokerStats = OperatorUtil.deserializeBrokerStats(record);
           if (brokerStats == null || brokerStats.getName() == null) {
+            OpenTsdbMetricConverter.incr(DoctorKafkaMetrics.MESSAGE_DESERIALIZE_ERROR, 1);
             continue;
           }
           ReplicaStatsManager.update(brokerStats);

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaStatsMain.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/KafkaStatsMain.java
@@ -142,7 +142,7 @@ public class KafkaStatsMain {
     if (tsdHostPort == null && ostrichPort == null) {
       LOG.info("OpenTSDB and Ostrich options missing, not starting Ostrich service");
     } else {
-      OperatorUtil.startOstrichService(tsdHostPort, Integer.parseInt(ostrichPort));
+      OperatorUtil.startOstrichService("kafkastats", tsdHostPort, Integer.parseInt(ostrichPort));
     }
     shutdownLatch.await(10, TimeUnit.SECONDS);
   }

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
@@ -276,7 +276,7 @@ public class OperatorUtil {
   }
 
 
-  public static void startOstrichService(String tsdbHostPort, int ostrichPort) {
+  public static void startOstrichService(String serviceName, String tsdbHostPort, int ostrichPort) {
     final int TSDB_METRICS_PUSH_INTERVAL_IN_MILLISECONDS = 10 * 1000;
     OstrichAdminService ostrichService = new OstrichAdminService(ostrichPort);
     ostrichService.startAdminHttpService();
@@ -287,7 +287,7 @@ public class OperatorUtil {
         MetricsPusher metricsPusher = new MetricsPusher(
             pushHostPort.getHost(),
             pushHostPort.getPort(),
-            new OpenTsdbMetricConverter("KafkaOperator", HostName),
+            new OpenTsdbMetricConverter(serviceName, HostName),
             TSDB_METRICS_PUSH_INTERVAL_IN_MILLISECONDS);
         metricsPusher.start();
         LOG.info("OpenTsdb metrics pusher started!");


### PR DESCRIPTION
1. Create a heartbeat thread that publishes heartbeat metrics once the backfilling is finished
2. Modifications of the signature of ostrich initializer to distinguish kafkastats agent and doctorkafka service metrics.