### PR TITLE
bump up jetty-server version to 9.4.17.v20190418

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<dropwizard.version>1.3.8</dropwizard.version>
-		<jetty.version>9.4.14.v20181114</jetty.version>
+		<jetty.version>9.4.17.v20190418</jetty.version>
 		<fasterxml.version>2.9.8</fasterxml.version>
 	</properties>
 


### PR DESCRIPTION
https://github.com/pinterest/doctorkafka/network/alert/drkafka/pom.xml/org.eclipse.jetty:jetty-server/open

CVE-2019-10247 More information
moderate severity
Vulnerable versions: >= 9.4.0, < 9.4.17.v20190418
Patched version: 9.4.17.v20190418
In Eclipse Jetty version 7.x, 8.x, 9.2.27 and older, 9.3.26 and older, and 9.4.16 and older, the server running on any OS and Jetty version combination will reveal the configured fully qualified directory base resource location on the output of the 404 error for not finding a Context that matches the requested path. The default server behavior on jetty-distribution and jetty-home will include at the end of the Handler tree a DefaultHandler, which is responsible for reporting this 404 error, it presents the various configured contexts as HTML for users to click through to. This produced HTML includes output that contains the configured fully qualified directory base resource location for each context.

CVE-2019-10246 More information
moderate severity
Vulnerable versions: >= 9.4.0, < 9.4.17.v20190418
Patched version: 9.4.17.v20190418
In Eclipse Jetty version 9.2.27, 9.3.26, and 9.4.16, the server running on Windows is vulnerable to exposure of the fully qualified Base Resource directory name on Windows to a remote client when it is configured for showing a Listing of directory contents. This information reveal is restricted to only the content in the configured base resource directories.

CVE-2019-10241 More information
low severity
Vulnerable versions: >= 9.4.0, < 9.4.17.v20190418
Patched version: 9.4.16.v20190411
In Eclipse Jetty version 9.2.26 and older, 9.3.25 and older, and 9.4.15 and older, the server is vulnerable to XSS conditions if a remote client USES a specially formatted URL against the DefaultServlet or ResourceHandler 