### PR TITLE
Add bindhost configuration

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
@@ -109,6 +109,7 @@ public class DoctorKafkaMain extends Application<DoctorKafkaAppConfig> {
     // Configure bind host and port number
     HttpConnectorFactory application = (HttpConnectorFactory) HttpConnectorFactory.application();
     application.setPort(config.getWebserverPort());
+    application.setBindHost(config.getWebserverBindHost());
     defaultServerFactory.setApplicationConnectors(Collections.singletonList(application));
   }
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaConfig.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/config/DoctorKafkaConfig.java
@@ -42,6 +42,7 @@ public class DoctorKafkaConfig {
   private static final String WEB_PORT = "web.port";
   private static final String NOTIFICATION_EMAILS = "emails.notification";
   private static final String ALERT_EMAILS = "emails.alert";
+  private static final String WEB_BIND_HOST = "web.bindhost";
 
   private PropertiesConfiguration configuration = null;
   private AbstractConfiguration drkafkaConfiguration = null;
@@ -177,6 +178,10 @@ public class DoctorKafkaConfig {
 
   public int getWebserverPort() {
     return drkafkaConfiguration.getInteger(WEB_PORT, 8080);
+  }
+  
+  public String getWebserverBindHost() {
+    return drkafkaConfiguration.getString(WEB_BIND_HOST, "0.0.0.0");
   }
 
   public DoctorKafkaClusterConfig getClusterConfigByZkUrl(String clusterZkUrl) {


### PR DESCRIPTION
Bind host configuration will allow dr. kafka to be run in localhost mode only so it can be run behind auth proxies.