### PR TITLE
Add broker decommission api

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/DoctorKafkaMain.java
@@ -8,9 +8,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.ImmutableList;
-import com.pinterest.doctorkafka.api.MaintenanceApi;
-import com.pinterest.doctorkafka.api.BrokerApi;
-import com.pinterest.doctorkafka.api.ClusterApi;
+
+import com.pinterest.doctorkafka.api.BrokersDecommissionApi;
+import com.pinterest.doctorkafka.api.ClustersMaintenanceApi;
+import com.pinterest.doctorkafka.api.BrokersApi;
+import com.pinterest.doctorkafka.api.ClustersApi;
 import com.pinterest.doctorkafka.config.DoctorKafkaAppConfig;
 import com.pinterest.doctorkafka.config.DoctorKafkaConfig;
 import com.pinterest.doctorkafka.replicastats.ReplicaStatsManager;
@@ -115,9 +117,10 @@ public class DoctorKafkaMain extends Application<DoctorKafkaAppConfig> {
 
   private void registerAPIs(Environment environment, DoctorKafka doctorKafka) {
     environment.jersey().setUrlPattern("/api/*");
-    environment.jersey().register(new BrokerApi());
-    environment.jersey().register(new ClusterApi(doctorKafka));
-    environment.jersey().register(new MaintenanceApi(doctorKafka));
+    environment.jersey().register(new BrokersApi(doctorKafka));
+    environment.jersey().register(new ClustersApi(doctorKafka));
+    environment.jersey().register(new ClustersMaintenanceApi(doctorKafka));
+    environment.jersey().register(new BrokersDecommissionApi(doctorKafka));
   }
 
   private void startMetricsService() {

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaCluster.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaCluster.java
@@ -219,7 +219,7 @@ public class KafkaCluster {
           continue;
         }
         LOG.debug("High traffic broker: {} : [{}, {}]",
-            broker.name(), broker.getMaxBytesIn(), broker.getMaxBytesOut());
+            broker.getName(), broker.getMaxBytesIn(), broker.getMaxBytesOut());
         result.add(broker);
       }
     }
@@ -239,7 +239,7 @@ public class KafkaCluster {
           double brokerBytesOut = broker.getMaxBytesOut();
           if (brokerBytesIn < averageBytesIn && brokerBytesOut < averageBytesOut) {
             LOG.info("Low traffic broker {} : [{}, {}]",
-                broker.name(), broker.getMaxBytesIn(), broker.getMaxBytesOut());
+                broker.getName(), broker.getMaxBytesIn(), broker.getMaxBytesOut());
             result.add(broker);
           }
         } catch (Exception e) {
@@ -293,7 +293,8 @@ public class KafkaCluster {
     BrokerStats latestStats = broker.getLatestStats();
     return latestStats== null ||
         latestStats.getHasFailure() ||
-        System.currentTimeMillis() - latestStats.getTimestamp() > INVALID_BROKERSTATS_TIME;
+        System.currentTimeMillis() - latestStats.getTimestamp() > INVALID_BROKERSTATS_TIME ||
+        broker.isDecommissioned();
   }
 
 
@@ -436,7 +437,7 @@ public class KafkaCluster {
   ){
     boolean success;
     KafkaBroker leastUsedBroker = brokerQueue.poll();
-    while (leastUsedBroker != null && replicaBrokers.contains(leastUsedBroker.id())) {
+    while (leastUsedBroker != null && replicaBrokers.contains(leastUsedBroker.getId())) {
       unusableBrokers.add(leastUsedBroker);
       leastUsedBroker = brokerQueue.poll();
     }
@@ -444,7 +445,7 @@ public class KafkaCluster {
       LOG.error("Failed to find a usable broker for fixing {}:{}", tp, oosBrokerId);
       success = false;
     } else {
-      LOG.info("LeastUsedBroker for replacing {} : {}", oosBrokerId, leastUsedBroker.id());
+      LOG.info("LeastUsedBroker for replacing {} : {}", oosBrokerId, leastUsedBroker.getId());
       success = preferredBroker == oosBrokerId ?
                 leastUsedBroker.reserveBandwidth(tp, inBoundReq, outBoundReq) :
                 leastUsedBroker.reserveBandwidth(tp, inBoundReq, 0);
@@ -472,7 +473,7 @@ public class KafkaCluster {
     }
     // we will get the broker with the least network usage
     KafkaBroker leastUsedBroker = brokerQueue.poll();
-    LOG.info("LeastUsedBroker for replacing {} : {}", topicPartition, leastUsedBroker.id());
+    LOG.info("LeastUsedBroker for replacing {} : {}", topicPartition, leastUsedBroker.getId());
     boolean success = leastUsedBroker.reserveBandwidth(topicPartition, tpBytesIn, tpBytesOut);
 
     if (!success) {

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/BrokersApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/BrokersApi.java
@@ -10,18 +10,24 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.pinterest.doctorkafka.DoctorKafka;
 import com.pinterest.doctorkafka.DoctorKafkaMain;
+import com.pinterest.doctorkafka.KafkaBroker;
 import com.pinterest.doctorkafka.KafkaClusterManager;
 
-@Path("/cluster/{clusterName}/broker")
+@Path("/clusters/{clusterName}/brokers")
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })
-public class BrokerApi {
+public class BrokersApi extends DoctorKafkaApi {
+
+    public BrokersApi(DoctorKafka drkafka){
+        super(drkafka);
+    }
 
     @GET
-    public List<String> getBrokerList(@PathParam("clusterName") String clusterName) {
-        KafkaClusterManager clusterManager = DoctorKafkaMain.doctorKafka.getClusterManager(clusterName);
-        return clusterManager.getAllBrokers().stream().map(b -> b.name()).collect(Collectors.toList());
+    public List<KafkaBroker> getBrokerList(@PathParam("clusterName") String clusterName) {
+        KafkaClusterManager clusterManager = checkAndGetClusterManager(clusterName);
+        return clusterManager.getAllBrokers();
     }
 
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/BrokersDecommissionApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/BrokersDecommissionApi.java
@@ -1,0 +1,52 @@
+package com.pinterest.doctorkafka.api;
+
+import com.pinterest.doctorkafka.DoctorKafka;
+import com.pinterest.doctorkafka.util.ApiUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+@Path("/clusters/{clusterName}/brokers/{brokerId}/admin/decommission")
+@Produces({MediaType.APPLICATION_JSON })
+@Consumes({MediaType.APPLICATION_JSON })
+public class BrokersDecommissionApi extends DoctorKafkaApi {
+
+  private static final Logger LOG = LogManager.getLogger(BrokersDecommissionApi.class);
+
+  public BrokersDecommissionApi(DoctorKafka drkafka) {
+    super(drkafka);
+  }
+
+  @GET
+  public boolean isBrokerDecommissioned(@PathParam("clusterName") String clusterName, @PathParam("brokerId") String brokerId) {
+    return checkAndGetBroker(clusterName, brokerId).isDecommissioned();
+  }
+
+  @PUT
+  public void decommissionBroker(@Context HttpServletRequest ctx,
+                                 @PathParam("clusterName") String clusterName,
+                                 @PathParam("brokerId") String brokerIdStr) {
+    checkAndGetClusterManager(clusterName).decommissionBroker(Integer.parseInt(brokerIdStr));
+    ApiUtils.logAPIAction(LOG, ctx, "Decommissioned for broker:" + brokerIdStr + " on cluster "+ clusterName);
+  }
+
+  @DELETE
+  public void cancelDecommissionBroker(@Context HttpServletRequest ctx,
+                                       @PathParam("clusterName") String clusterName,
+                                       @PathParam("brokerId") String brokerIdStr) {
+    checkAndGetClusterManager(clusterName).cancelDecommissionBroker(Integer.parseInt(brokerIdStr));
+    ApiUtils.logAPIAction(LOG, ctx, "Decommissioned cancelled for broker:" + brokerIdStr + " on cluster "+ clusterName);
+  }
+
+}

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/ClustersApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/ClustersApi.java
@@ -10,20 +10,18 @@ import javax.ws.rs.core.MediaType;
 
 import com.pinterest.doctorkafka.DoctorKafka;
 
-@Path("/cluster")
+@Path("/clusters")
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })
-public class ClusterApi {
+public class ClustersApi extends DoctorKafkaApi {
 
-  private DoctorKafka drKafka;
-
-  public ClusterApi(DoctorKafka drKafka) {
-    this.drKafka = drKafka;
+  public ClustersApi(DoctorKafka drKafka) {
+    super(drKafka);
   }
 
   @GET
   public List<String> getClusterNames() {
-    return drKafka.getClusterNames();
+    return getDrkafka().getClusterNames();
   }
 
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/ClustersMaintenanceApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/ClustersMaintenanceApi.java
@@ -4,7 +4,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -17,17 +16,17 @@ import org.apache.logging.log4j.Logger;
 
 import com.pinterest.doctorkafka.DoctorKafka;
 import com.pinterest.doctorkafka.KafkaClusterManager;
+import com.pinterest.doctorkafka.util.ApiUtils;
 
-@Path("/cluster/{clusterName}/admin/maintenance")
+@Path("/clusters/{clusterName}/admin/maintenance")
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })
-public class MaintenanceApi {
+public class ClustersMaintenanceApi extends DoctorKafkaApi {
 
-  private static final Logger LOG = LogManager.getLogger(MaintenanceApi.class);
-  private DoctorKafka drKafka;
+  private static final Logger LOG = LogManager.getLogger(ClustersMaintenanceApi.class);
 
-  public MaintenanceApi(DoctorKafka drKafka) {
-    this.drKafka = drKafka;
+  public ClustersMaintenanceApi(DoctorKafka drKafka) {
+    super(drKafka);
   }
 
   @GET
@@ -41,8 +40,7 @@ public class MaintenanceApi {
       @PathParam("clusterName") String clusterName) {
     KafkaClusterManager clusterManager = checkAndGetClusterManager(clusterName);
     clusterManager.enableMaintenanceMode();
-    LOG.info("Enabled maintenance mode for cluster:" + clusterName + " by user:"
-        + ctx.getRemoteUser() + " from ip:" + ctx.getRemoteHost());
+    ApiUtils.logAPIAction(LOG, ctx, "Enabled maintenance mode for cluster:" + clusterName);
   }
 
   @DELETE
@@ -50,16 +48,7 @@ public class MaintenanceApi {
       @PathParam("clusterName") String clusterName) {
     KafkaClusterManager clusterManager = checkAndGetClusterManager(clusterName);
     clusterManager.disableMaintenanceMode();
-    LOG.info("Dsiabled maintenance mode for cluster:" + clusterName + " by user:"
-        + ctx.getRemoteUser() + " from ip:" + ctx.getRemoteHost());
-  }
-
-  private KafkaClusterManager checkAndGetClusterManager(String clusterName) {
-    KafkaClusterManager clusterManager = drKafka.getClusterManager(clusterName);
-    if (clusterManager == null) {
-      throw new NotFoundException("Unknown clustername:" + clusterName);
-    }
-    return clusterManager;
+    ApiUtils.logAPIAction(LOG, ctx, "Disabled maintenance mode for cluster:" + clusterName);
   }
 
 }

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/api/DoctorKafkaApi.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/api/DoctorKafkaApi.java
@@ -1,0 +1,44 @@
+package com.pinterest.doctorkafka.api;
+
+import com.pinterest.doctorkafka.DoctorKafka;
+import com.pinterest.doctorkafka.KafkaBroker;
+import com.pinterest.doctorkafka.KafkaClusterManager;
+
+import javax.ws.rs.NotFoundException;
+
+public abstract class DoctorKafkaApi {
+  private DoctorKafka drkafka;
+
+  public DoctorKafkaApi() {
+    this.drkafka = null;
+  }
+
+  public DoctorKafkaApi(DoctorKafka drkafka) {
+    this.drkafka = drkafka;
+  }
+
+  protected DoctorKafka getDrkafka() {
+    return drkafka;
+  }
+
+  protected KafkaClusterManager checkAndGetClusterManager(String clusterName) {
+    KafkaClusterManager clusterManager = drkafka.getClusterManager(clusterName);
+    if (clusterManager == null) {
+      throw new NotFoundException("Unknown clustername:" + clusterName);
+    }
+    return clusterManager;
+  }
+
+  protected KafkaBroker checkAndGetBroker(String clusterName, String brokerId) {
+    KafkaClusterManager clusterManager = checkAndGetClusterManager(clusterName);
+    Integer id = Integer.parseInt(brokerId);
+    KafkaBroker broker = clusterManager.getCluster().getBroker(id);
+    if (broker == null) {
+      throw new NotFoundException("Unknown brokerId: " + brokerId);
+    }
+    return broker;
+  }
+
+
+
+}

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/notification/Email.java
@@ -89,6 +89,18 @@ public class Email {
     sendTo(emails, title, content);
   }
 
+  public static void notifyOnDecommissioningBroker(String[] emails, String clusterName, String brokerId) {
+    String title = "Decommissioning broker " + brokerId + " on " + clusterName;
+    String content = "Broker:" + brokerId + " Cluster:" + clusterName + " is getting decommissioned";
+    sendTo(emails, title, content);
+  }
+
+  public static void notifyOnCancelledDecommissioningBroker(String[] emails, String clusterName, String brokerId) {
+    String title = "Cancelled decommissioning broker " + brokerId + " on " + clusterName;
+    String content = "Broker:" + brokerId + " Cluster:" + clusterName + " decommission cancelled";
+    sendTo(emails, title, content);
+  }
+
   public static void alertOnNoStatsBrokers(String[] emails,
                                            String clusterName,
                                            List<Broker> noStatsBrokers) {
@@ -129,7 +141,7 @@ public class Email {
       reassignmentFailures.stream().forEach(pair -> {
         KafkaBroker broker = pair.getKey();
         TopicPartition topicPartition = pair.getValue();
-        sb.append("Broker : " + broker.name() + ", " + topicPartition);
+        sb.append("Broker : " + broker.getName() + ", " + topicPartition);
       });
     }
     if (downBrokers != null && !downBrokers.isEmpty()) {

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/ClusterInfoServlet.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/servlet/ClusterInfoServlet.java
@@ -90,14 +90,14 @@ public class ClusterInfoServlet extends DoctorKafkaServlet {
         writer.print(String.format("<div class=\"container\"> overloaded brokers (%d) : ",
             overloadedBrokers.size()));
         for (KafkaBroker broker : overloadedBrokers) {
-          writer.print(broker.name() + ",");
+          writer.print(broker.getName() + ",");
         }
         writer.print("</div>");
 
         writer.print(String.format("<div class=\"container\"> under-utilized brokers (%d): ",
             underutilized.size()));
         for (KafkaBroker broker : underutilized) {
-          writer.print(broker.name() + ",");
+          writer.print(broker.getName() + ",");
         }
         writer.print("</div>");
       }
@@ -105,8 +105,9 @@ public class ClusterInfoServlet extends DoctorKafkaServlet {
       writer.print("<table class=\"table table_stripped text-left\">");
       writer.print("<thead> <tr>");
       String thStr = String.format(
-          "<th>%s</th> <th>%s</th> <th>%s</th> <th>%s</th> <th>%s</th> <th>%s</th>",
-          "BrokerId", "BrokerName", "MaxIn (Mb/s)", "MaxOut (Mb/s)", "#Partitions", "Last Update");
+          "<th>%s</th> <th>%s</th> <th>%s</th> <th>%s</th> <th>%s</th> <th>%s</th> <th>%s</th>",
+          "BrokerId", "BrokerName", "MaxIn (Mb/s)", "MaxOut (Mb/s)", "#Partitions", "Last Update",
+          "Decommissioned");
       writer.print(thStr + "</tr> </thead>");
       writer.print("<tbody>");
 
@@ -119,7 +120,7 @@ public class ClusterInfoServlet extends DoctorKafkaServlet {
         KafkaBroker broker = brokerEntry.getValue();
         double maxMbInPerSec = broker.getMaxBytesIn() / 1024.0 / 1024.0;
         double maxMbOutPerSec = broker.getMaxBytesOut() / 1024.0 / 1024.0;
-        double lastUpdateTime = (now - broker.lastStatsTimestamp()) / 1000.0;
+        double lastUpdateTime = (now - broker.getLastStatsTimestamp()) / 1000.0;
         
         String lastUpateTimeHtml =
             lastUpdateTime < 600
@@ -128,11 +129,12 @@ public class ClusterInfoServlet extends DoctorKafkaServlet {
 
         int partitionCount = broker.getLatestStats().getNumReplicas();
         String html = String.format(
-            "<td>%d</td> <td> %s </td> <td> %.2f</td> <td>%.2f</td> <td>%d</td> %s",
+            "<td>%d</td> <td> %s </td> <td> %.2f</td> <td>%.2f</td> <td>%d</td> %s <td> %s </td>",
             brokerEntry.getKey(),
             "<a href=\"/servlet/brokerstats?cluster=" + clusterName
-                + "&brokerid=" + broker.id() + "\">" + broker.name() + "</a>",
-            maxMbInPerSec, maxMbOutPerSec, partitionCount, lastUpateTimeHtml);
+                + "&brokerid=" + broker.getId() + "\">" + broker.getName() + "</a>",
+            maxMbInPerSec, maxMbOutPerSec, partitionCount, lastUpateTimeHtml,
+            broker.isDecommissioned());
 
         writer.print(html);
         writer.print("</tr>");

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/util/ApiUtils.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/util/ApiUtils.java
@@ -1,0 +1,11 @@
+package com.pinterest.doctorkafka.util;
+
+import org.apache.logging.log4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class ApiUtils {
+  public static void logAPIAction(Logger LOG, HttpServletRequest ctx, String message) {
+    LOG.info("User from:" + ctx.getRemoteUser() + " from ip:" + ctx.getRemoteHost() + " " + message);
+  }
+}

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/util/ReassignmentInfo.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/util/ReassignmentInfo.java
@@ -19,7 +19,7 @@ public class ReassignmentInfo {
     @Override
     public String toString() {
       String result = topicPartition.toString() + ": ";
-      result += source.name() + " -> " + dest.name();
+      result += source.getName() + " -> " + dest.getName();
       return result;
     }
 }

--- a/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
+++ b/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
@@ -170,7 +170,7 @@ class KafkaClusterTest {
       BrokerStats bs = new BrokerStats();
       bs.setTimestamp(System.currentTimeMillis());
       broker.setLatestStats(bs);
-      kafkaCluster.brokers.put(broker.id(), broker);
+      kafkaCluster.brokers.put(broker.getId(), broker);
     }
 
     Set<TopicPartition> replicaSet = new HashSet<>();
@@ -210,7 +210,7 @@ class KafkaClusterTest {
       // element check
       assertTrue(actualAssignments
           .stream()
-          .map(broker -> broker.id())
+          .map(broker -> broker.getId())
           .collect(Collectors.toList())
           .containsAll(expectedAssignments));
     }
@@ -248,7 +248,7 @@ class KafkaClusterTest {
       // element check
       assertTrue(actualAssignments
           .stream()
-          .map(broker -> broker.id())
+          .map(broker -> broker.getId())
           .collect(Collectors.toList())
           .containsAll(expectedAssignments));
     }
@@ -292,7 +292,7 @@ class KafkaClusterTest {
       BrokerStats bs = new BrokerStats();
       bs.setTimestamp(System.currentTimeMillis());
       broker.setLatestStats(bs);
-      kafkaCluster.brokers.put(broker.id(), broker);
+      kafkaCluster.brokers.put(broker.getId(), broker);
     }
 
     Set<TopicPartition> replicaSet = new HashSet<>();
@@ -375,7 +375,7 @@ class KafkaClusterTest {
       BrokerStats bs = new BrokerStats();
       bs.setTimestamp(System.currentTimeMillis());
       broker.setLatestStats(bs);
-      kafkaCluster.brokers.put(broker.id(), broker);
+      kafkaCluster.brokers.put(broker.getId(), broker);
     }
 
     Set<TopicPartition> replicaSet = new HashSet<>();


### PR DESCRIPTION
1. Added Broker decommissioning API endpoint
2. Expose decommission status in UI
3. Small refactor of API code for reusability

Notes: 
Currently, a decommissioned broker
* WILL:
  1. Be ignored when checking for dead brokers (and thus no replacement will happen)
  2. Be ignored during URP reassignments
  3. Still update stats so it can catch up if decommission is cancelled
* WILL NOT:
  1. Reassign the partitions to other brokers, you have to do it manually

Decommissioning is ephemeral for now, state is not preserved in ZK, so if a restart happens, we will have to do it again