### PR TITLE
Add safeguard so that dry-runs won't perform replacement actions

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/KafkaClusterManager.java
@@ -969,12 +969,17 @@ public class KafkaClusterManager implements Runnable {
         return false;
       }
 
-      LOG.info("Replacing {}  in {}", brokerName, clusterName);
-      brokerReplacer.replaceBroker(brokerName);
-      zookeeperClient.recordBrokerTermination(clusterName, brokerName);
-      actionReporter.sendMessage(clusterName, "broker replacement : " + brokerName);
-      Email.notifyOnBrokerReplacement(drkafkaConfig.getNotificationEmails(),
-          clusterName, brokerName);
+      if (!clusterConfig.dryRun()){
+        LOG.info("Replacing {}  in {}", brokerName, clusterName);
+        brokerReplacer.replaceBroker(brokerName);
+        zookeeperClient.recordBrokerTermination(clusterName, brokerName);
+        actionReporter.sendMessage(clusterName, "broker replacement : " + brokerName);
+        Email.notifyOnBrokerReplacement(drkafkaConfig.getNotificationEmails(),
+            clusterName, brokerName);
+      } else {
+        LOG.info("Dry run: Replacing {} in {}", brokerName, clusterName);
+      }
+
     }
     return true;
   }


### PR DESCRIPTION
Previously dry runs would not prevent broker replacement.