### PR TITLE
Upgrade jetty to 9.4.18.v20190429 and dropwizard to 1.3.10

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -14,8 +14,8 @@
 	<artifactId>doctorkafka</artifactId>
 
 	<properties>
-		<dropwizard.version>1.3.8</dropwizard.version>
-		<jetty.version>9.4.17.v20190418</jetty.version>
+		<dropwizard.version>1.3.10</dropwizard.version>
+		<jetty.version>9.4.18.v20190429</jetty.version>
 		<fasterxml.version>2.9.8</fasterxml.version>
 	</properties>
 


### PR DESCRIPTION
We are hitting this issue https://github.com/eclipse/jetty.project/pull/3550 after patching jetty to 9.4.17.v20190418. Upgrading jetty to 9.4.18 to fix issue.
Also upgrading dropwizard from 1.3.8 to 1.3.10.