### PR TITLE
pin avro plugin version to 1.8.2

### DIFF
--- a/kafkastats/pom.xml
+++ b/kafkastats/pom.xml
@@ -94,6 +94,7 @@
             <plugin>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
+                <version>1.8.2</version>
                 <configuration>
                     <stringType>String</stringType>
                 </configuration>


### PR DESCRIPTION
1.9.0 breaks the build, pinning avro-maven-plugin to previous released version.