### PR TITLE
bump jackson-databind version from 2.9.8 to 2.9.9

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<dropwizard.version>1.3.11</dropwizard.version>
 		<jetty.version>9.4.18.v20190429</jetty.version>
-		<fasterxml.version>2.9.8</fasterxml.version>
+		<fasterxml.version>2.9.9</fasterxml.version>
 	</properties>
 
 	<licenses>


### PR DESCRIPTION
This is to address the security alert on jackson-databind. See the following link for details. 

https://github.com/pinterest/doctorkafka/network/alert/drkafka/pom.xml/com.fasterxml.jackson.core:jackson-databind/open