### PR TITLE
update jackson-databind to 2.9.9.1

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<dropwizard.version>1.3.11</dropwizard.version>
 		<jetty.version>9.4.18.v20190429</jetty.version>
-		<fasterxml.version>2.9.9</fasterxml.version>
+		<fasterxml.version>2.9.9.1</fasterxml.version>
 	</properties>
 
 	<licenses>


### PR DESCRIPTION
Update  jackson-databind to 2.9.9.1 for the security alert. 


https://github.com/pinterest/doctorkafka/network/alert/drkafka/pom.xml/com.fasterxml.jackson.core:jackson-databind/open


    CVE-2019-12814 More information
    moderate severity
    Vulnerable versions: >= 2.0.0, < 2.9.9.1
    Patched version: 2.9.9.1
    A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. When 
    Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON 
    endpoint and the service has JDOM 1.x or 2.x jar in the classpath, an attacker can send a specifically 
    crafted JSON message that allows them to read arbitrary local files on the server.

