### PR TITLE
Fix jackson-databind 2.9.9.1 version issue

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<dropwizard.version>1.3.11</dropwizard.version>
 		<jetty.version>9.4.18.v20190429</jetty.version>
-		<fasterxml.version>2.9.9.1</fasterxml.version>
+		<fasterxml.version>2.9.9</fasterxml.version>
 	</properties>
 
 	<licenses>
@@ -167,7 +167,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${fasterxml.version}</version>
+			<version>2.9.9.1</version>
 		</dependency>
 		<dependency>
 	        <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
version bump 2.9.9.1 is only available for `jackson-databind`