### PR TITLE
Fix BrokerStatsMonitor issues

### DIFF
--- a/drkafka/src/test/java/com/pinterest/doctorkafka/ClusterInfoServletTest.java
+++ b/drkafka/src/test/java/com/pinterest/doctorkafka/ClusterInfoServletTest.java
@@ -21,7 +21,7 @@ public class ClusterInfoServletTest extends Mockito {
     DoctorKafka mockDoctor = mock(DoctorKafka.class);
     DoctorKafkaMain.doctorKafka = mockDoctor;
     KafkaClusterManager clusterManager = mock(KafkaClusterManager.class);
-    KafkaCluster cluster = new KafkaCluster(clusterName);
+    KafkaCluster cluster = new KafkaCluster(clusterName, 1440);
 
     when(mockDoctor.getClusterManager(clusterName)).thenReturn(clusterManager);
     when(clusterManager.getCluster()).thenReturn(cluster);

--- a/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaBrokerTest.java
+++ b/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaBrokerTest.java
@@ -15,7 +15,7 @@ public class KafkaBrokerTest {
 
     DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.config.yaml");
     DoctorKafkaClusterConfig clusterConfig = config.getClusterConfigByName("cluster1");
-    KafkaCluster kafkaCluster = new KafkaCluster(clusterConfig.getZkUrl());
+    KafkaCluster kafkaCluster = new KafkaCluster(clusterConfig.getZkUrl(), 1440);
 
     KafkaBroker a = new KafkaBroker("", kafkaCluster, 0, 0, 0);
     KafkaBroker b = new KafkaBroker("", kafkaCluster, 1, 0, 0);

--- a/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
+++ b/drkafka/src/test/java/com/pinterest/doctorkafka/KafkaClusterTest.java
@@ -56,7 +56,7 @@ class KafkaClusterTest {
     DoctorKafkaConfig config = new DoctorKafkaConfig("./config/doctorkafka.config.yaml");
     doctorKafkaClusterConfig = config.getClusterConfigByName(CLUSTER_NAME);
     zookeeper_url = doctorKafkaClusterConfig.getZkUrl();
-    kafkaCluster = new KafkaCluster(zookeeper_url);
+    kafkaCluster = new KafkaCluster(zookeeper_url, 1440);
     kafkaCluster.setBytesInPerSecLimit(BYTES_IN_SEC_LIMIT);
     kafkaCluster.setBytesOutPerSecLimit(BYTES_OUT_SEC_LIMIT);
   }

--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/util/OperatorUtil.java
@@ -247,8 +247,7 @@ public class OperatorUtil {
     Properties props = new Properties();
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
     props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupName);
-    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-    props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaUtils.BYTE_ARRAY_DESERIALIZER);
     props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaUtils.BYTE_ARRAY_DESERIALIZER);
 


### PR DESCRIPTION
Consolidation of BrokerStatsMonitor 

1. Make KafkaCluster sliding window configurable

2. Removing auto-commit completely from BrokerStatsMonitor Kafka consumers.
BrokerStatsMonitor long-running processor will now assign to TopicPartitions manually and seek to offsets left over from the back-fill processors.
    Previously the behaviour was to commit and use high level kafka subscriptions, which is inefficient since the restart might be a while later and unnecessary messages would be read.