### PR TITLE
fix com.fasterxml.jackson.core:jackson-databind security alert

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<dropwizard.version>1.3.11</dropwizard.version>
 		<jetty.version>9.4.18.v20190429</jetty.version>
-		<fasterxml.version>2.9.9</fasterxml.version>
+		<fasterxml.version>2.9.9.1</fasterxml.version>
 	</properties>
 
 	<licenses>


### PR DESCRIPTION
Remediation
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.9.2 or later. For example:

<dependency>
  <groupId>com.fasterxml.jackson.core</groupId>
  <artifactId>jackson-databind</artifactId>
  <version>[2.9.9.2,)</version>
</dependency>

https://github.com/pinterest/doctorkafka/network/alert/drkafka/pom.xml/com.fasterxml.jackson.core:jackson-databind/open