### PR TITLE
let kafkastats set broker's name to hostname by default

### DIFF
--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
@@ -407,10 +407,10 @@ public class BrokerStatsRetriever {
    */
   private void setBrokerInstanceInfo() {
     BufferedReader input = null;
+    brokerStats.setName(OperatorUtil.getHostname());
 
     // out quick if we don't want to use ec2metadata command.
     if (disableEc2metadata) {
-      brokerStats.setName(OperatorUtil.getHostname());
       return;
     }
     


### PR DESCRIPTION
If we are to use `ec2metadata`, and ec2 instances do not have hostname set explicitly, then the name field will not be populated, causing drkafka ignoring the record: https://github.com/pinterest/doctorkafka/blob/ee5c005328047407782832f432911fa08f2199b3/drkafka/src/main/java/com/pinterest/doctorkafka/replicastats/BrokerStatsProcessor.java#L76

This change sets the name field to hostname by default.