### PR TITLE
Fix replacement of decommissioned brokers

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/operator/cluster/kafka/BrokerReplacementOperator.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/operator/cluster/kafka/BrokerReplacementOperator.java
@@ -62,7 +62,12 @@ public class BrokerReplacementOperator extends KafkaOperator {
       if(!isClusterReplacementCooldownExpired(state)) {
         LOG.info("Cannot replace brokers on {} due to replace frequency limitation", state.getClusterName());
       } else {
-        victim = toBeReplacedBrokers.get(0);
+        for (KafkaBroker broker : toBeReplacedBrokers){
+          if (!broker.isDecommissioned()){
+            victim = broker;
+            break;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Decommissioned brokers should be skipped when evaluating which broker to replace