### PR TITLE
Make state easier to access

### DIFF
--- a/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/context/state/cluster/kafka/KafkaState.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/context/state/cluster/kafka/KafkaState.java
@@ -1,8 +1,8 @@
 package com.pinterest.doctorkafka.plugins.context.state.cluster.kafka;
 
 import com.pinterest.doctorkafka.KafkaBroker;
-import com.pinterest.doctorkafka.plugins.context.state.cluster.ClusterState;
 import com.pinterest.doctorkafka.KafkaCluster;
+import com.pinterest.doctorkafka.plugins.context.state.cluster.ClusterState;
 import com.pinterest.doctorkafka.util.ZookeeperClient;
 
 import kafka.cluster.Broker;
@@ -31,14 +31,6 @@ public class KafkaState extends ClusterState {
 
   public void setKafkaCluster(KafkaCluster kafkaCluster) {
     this.kafkaCluster = kafkaCluster;
-  }
-
-  public ZkUtils getZkUtils() {
-    return zkUtils;
-  }
-
-  public void setZkUtils(ZkUtils zkUtils) {
-    this.zkUtils = zkUtils;
   }
 
   public ZookeeperClient getKafkaClusterZookeeperClient() {

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/monitor/cluster/kafka/NoBrokerstatsBrokerMonitor.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/monitor/cluster/kafka/NoBrokerstatsBrokerMonitor.java
@@ -1,9 +1,11 @@
 package com.pinterest.doctorkafka.plugins.monitor.cluster.kafka;
 
 import com.pinterest.doctorkafka.plugins.context.state.cluster.kafka.KafkaState;
+import com.pinterest.doctorkafka.util.KafkaUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import kafka.cluster.Broker;
+import kafka.utils.ZkUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import scala.collection.Seq;
@@ -34,7 +36,8 @@ public class NoBrokerstatsBrokerMonitor extends KafkaMonitor {
     if(state.getKafkaCluster() == null) {
       return null;
     }
-    Seq<Broker> brokerSeq = state.getZkUtils().getAllBrokersInCluster();
+    ZkUtils zkUtils = KafkaUtils.getZkUtils(state.getZkUrl());
+    Seq<Broker> brokerSeq = zkUtils.getAllBrokersInCluster();
     List<Broker> brokers = scala.collection.JavaConverters.seqAsJavaList(brokerSeq);
     List<Broker> noStatsBrokers = new ArrayList<>();
 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/monitor/cluster/kafka/URPMonitor.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/monitor/cluster/kafka/URPMonitor.java
@@ -63,7 +63,7 @@ public class URPMonitor extends KafkaMonitor {
   }
 
   public KafkaState observe(KafkaState state){
-    ZkUtils zkUtils = state.getZkUtils();
+    ZkUtils zkUtils = KafkaUtils.getZkUtils(state.getZkUrl());
     Seq<String> topicsSeq = zkUtils.getAllTopics();
     List<String> topics = scala.collection.JavaConverters.seqAsJavaList(topicsSeq);
     scala.collection.mutable.Map<String, scala.collection.Map<Object, Seq<Object>>> 

--- a/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/operator/cluster/kafka/URPReassignmentOperator.java
+++ b/drkafka/src/main/java/com/pinterest/doctorkafka/plugins/operator/cluster/kafka/URPReassignmentOperator.java
@@ -10,6 +10,7 @@ import com.pinterest.doctorkafka.plugins.context.event.GenericEvent;
 import com.pinterest.doctorkafka.plugins.context.event.NotificationEvent;
 import com.pinterest.doctorkafka.plugins.context.state.cluster.kafka.KafkaState;
 import com.pinterest.doctorkafka.plugins.errors.PluginConfigurationException;
+import com.pinterest.doctorkafka.util.KafkaUtils;
 import com.pinterest.doctorkafka.util.OpenTsdbMetricConverter;
 import com.pinterest.doctorkafka.util.OperatorUtil;
 import com.pinterest.doctorkafka.util.OutOfSyncReplica;
@@ -177,12 +178,13 @@ public class URPReassignmentOperator extends KafkaOperator {
   protected void handleUnderReplicatedPartitions(KafkaState state, List<PartitionInfo> urps) {
     LOG.info("Start handling under-replicated partitions for {}", state.getClusterName());
     this.topicPartitionAssignments.clear();
+    ZkUtils zkUtils = KafkaUtils.getZkUtils(state.getZkUrl());
 
     // filter out topic partitions that have more replicas than what is required
     List<OutOfSyncReplica> oosReplicas = urps.stream().map(urp -> {
       TopicPartition tp = new TopicPartition(urp.topic(), urp.partition());
       OutOfSyncReplica oosReplica = new OutOfSyncReplica(urp);
-      oosReplica.replicaBrokers = getReplicaAssignment(state.getZkUtils(), tp);
+      oosReplica.replicaBrokers = getReplicaAssignment(zkUtils, tp);
       return oosReplica;
     }).collect(Collectors.toList());
 


### PR DESCRIPTION
State is accessible within the cluster manager. Removed ZkUtils from KafkaState** since it is used by limited number of modules.