### PR TITLE
Resolve runtime Maven dependency conflicts

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -14,7 +14,7 @@
 	<artifactId>doctorkafka</artifactId>
 
 	<properties>
-		<dropwizard.version>1.3.15</dropwizard.version>
+		<dropwizard.version>1.1.8</dropwizard.version>
 	</properties>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.8.4</version>
+		</dependency>
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.3.1</version>


### PR DESCRIPTION
The current Maven pom leads to dependecy conflicts on some of the `com.fasterxml.jackson` modules where different incompatible versions of them are used by Ostrich and DropWizard dependencies.
Since there is no recent version of Ostrich module, downgrading the DropWizard version helps resolving the conflicts.