### PR TITLE
Fix javadoc building for newer jdk versions

### DIFF
--- a/drkafka/pom.xml
+++ b/drkafka/pom.xml
@@ -197,6 +197,7 @@
 				<version>2.9.1</version>
 				<configuration>
 					<additionalparam>-Xdoclint:none</additionalparam>
+                    <source>8</source>
 				</configuration>
 				<executions>
 					<execution>

--- a/kafkastats/pom.xml
+++ b/kafkastats/pom.xml
@@ -129,6 +129,7 @@
                 <version>2.9.1</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
I use Java 14.0.1 (via zulu). Trying to build doctorkafka (have to skip tests since I think you are depending on some zookeeper setup for the doctorkafka tests) results in the following error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project doctorkafka: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/7/docs/api/ are in the unnamed module.
```

After a quick google, the fix described in https://bugs.openjdk.java.net/browse/JDK-8212233 seems to work, so I just added that here.